### PR TITLE
Add 2026 US Quality Core v0.5.0 resources

### DIFF
--- a/resources/us_quality_core_bundle_patient.json
+++ b/resources/us_quality_core_bundle_patient.json
@@ -5012,11 +5012,11 @@
               }
             ],
             "active": true,
-            "name": "Genzyme",
+            "name": "Example Org",
             "telecom": [
               {
                 "system": "url",
-                "value": "https://www.sanofigenzyme.com/",
+                "value": "https://example.com/",
                 "use": "work"
               }
             ],

--- a/resources/us_quality_core_bundle_patient.json
+++ b/resources/us_quality_core_bundle_patient.json
@@ -1,0 +1,8571 @@
+{
+  "type": "transaction",
+  "resourceType": "Bundle",
+  "entry": [
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Endpoint/usqualitycore-r4-endpoint"
+      },
+      "resource": {
+        "resourceType": "Endpoint",
+        "id": "usqualitycore-r4-endpoint",
+        "status": "active",
+        "connectionType": {
+          "system": "http://terminology.hl7.org/CodeSystem/endpoint-connection-type",
+          "code": "direct-project",
+          "display": "Direct Project"
+        },
+        "payloadType": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/endpoint-payload-type",
+                "code": "any",
+                "display": "Any"
+              }
+            ],
+            "text": "Any"
+          }
+        ],
+        "address": "mailto:Willena258.Oberbrunner298@example.com",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-r4-endpoint</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Media/usqualitycore-r4-media"
+      },
+      "resource": {
+        "resourceType": "Media",
+        "id": "usqualitycore-r4-media",
+        "status": "completed",
+        "content": {
+          "contentType": "application/dicom",
+          "link": "http://imaging.acme.com/wado/server?requestType=WADO&contentType=application%2Fdicom&studyUid=1.2.840.113619.2.21.848.34082.0.538976288.3&seriesUid=1.2.840.113619.2.21.3408.700.0.757923840.3.0&objectUid=1.2.840.11361907579238403408700.3.1.04.19970327150033"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-r4-media</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Specimen/usqualitycore-specimen"
+      },
+      "resource": {
+        "resourceType": "Specimen",
+        "id": "usqualitycore-specimen",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-specimen|6.1.0"
+          ]
+        },
+        "type": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "version": "http://snomed.info/sct/731000124108",
+              "code": "119364003",
+              "display": "Serum sample"
+            },
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+              "code": "SER",
+              "display": "Serum"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "collection": {
+          "collectedDateTime": "2022-09-27T18:07:12Z"
+        },
+        "container": [
+          {
+            "type": {
+              "text": "Serum Separator Tube"
+            }
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-specimen</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "DocumentReference/usqualitycore-document-reference"
+      },
+      "resource": {
+        "resourceType": "DocumentReference",
+        "id": "usqualitycore-document-reference",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference|6.1.0"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://github.com/inferno-framework/us-quality-core-test-kit/document-reference",
+            "value": "usqualitycore-document-reference"
+          }
+        ],
+        "status": "current",
+        "type": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "34117-2",
+              "display": "History and physical note"
+            }
+          ],
+          "text": "History and physical note"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category",
+                "code": "clinical-note",
+                "display": "Clinical Note"
+              }
+            ],
+            "text": "Clinical Note"
+          }
+        ],
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "date": "2015-02-15T16:30:00Z",
+        "author": [
+          {
+            "reference": "Practitioner/usqualitycore-practitioner"
+          }
+        ],
+        "custodian": {
+          "reference": "Organization/usqualitycore-organization"
+        },
+        "description": "History and physical note for the US Quality Core test kit encounter.",
+        "content": [
+          {
+            "attachment": {
+              "contentType": "text/plain",
+              "data": "VVMgUXVhbGl0eSBDb3JlIHRlc3Qga2l0IERvY3VtZW50UmVmZXJlbmNlIGNsaW5pY2FsIG5vdGUu",
+              "url": "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
+              "title": "US Quality Core test kit clinical note",
+              "creation": "2015-02-15T16:30:00Z"
+            },
+            "format": {
+              "system": "http://ihe.net/fhir/ihe.formatcode.fhir/CodeSystem/formatcode",
+              "code": "urn:hl7-org:sdwg:ccda-structuredBody:2.1",
+              "display": "For documents following C-CDA 2.1 constraints using a structured body."
+            }
+          }
+        ],
+        "context": {
+          "encounter": [
+            {
+              "reference": "Encounter/usqualitycore-encounter"
+            }
+          ],
+          "period": {
+            "start": "2015-02-15T14:30:00+01:00",
+            "end": "2015-02-15T16:30:00+01:00"
+          }
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-document-reference</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-us-core-observation-pregnancyintent"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-us-core-observation-pregnancyintent",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-pregnancyintent|6.1.0"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history",
+                "display": "Social History"
+              }
+            ],
+            "text": "Social History"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "86645-9",
+              "display": "Pregnancy intention in the next year - Reported"
+            }
+          ],
+          "text": "Pregnancy intention in the next year - Reported"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectiveDateTime": "2022-09-23T22:39:43Z",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization"
+          }
+        ],
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "version": "http://snomed.info/sct/731000124108",
+              "code": "454381000124105",
+              "display": "Not sure of desire to become pregnant (finding)"
+            }
+          ],
+          "text": "Not sure of desire to become pregnant (finding)"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-us-core-observation-pregnancyintent</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-us-core-observation-pregnancystatus"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-us-core-observation-pregnancystatus",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-pregnancystatus|6.1.0"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history",
+                "display": "Social History"
+              }
+            ],
+            "text": "Social History"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "82810-3",
+              "display": "Pregnancy status"
+            }
+          ],
+          "text": "Pregnancy status"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectiveDateTime": "2022-08-24T10:39:52Z",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization"
+          }
+        ],
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "77386006",
+              "display": "Pregnant"
+            }
+          ],
+          "text": "Pregnant"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-us-core-observation-pregnancystatus</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-us-core-smokingstatus"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-us-core-smokingstatus",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus|6.1.0"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history",
+                "display": "Social History"
+              }
+            ],
+            "text": "Social History"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "72166-2",
+              "display": "Tobacco smoking status"
+            }
+          ],
+          "text": "Tobacco smoking status"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectiveDateTime": "2016-03-18T05:27:04Z",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization"
+          }
+        ],
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "428041000124106",
+              "display": "Occasional tobacco smoker"
+            }
+          ],
+          "text": "Occasional tobacco smoker"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-us-core-smokingstatus</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-us-core-observation-occupation"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-us-core-observation-occupation",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-occupation|6.1.0"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history",
+                "display": "Social History"
+              }
+            ],
+            "text": "Social History"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "11341-5",
+              "display": "History of Occupation"
+            }
+          ],
+          "text": "History of Occupation"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectivePeriod": {
+          "start": "2015-04-24"
+        },
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization"
+          }
+        ],
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/PHOccupationalDataForHealthODH",
+              "code": "31-1014.00.007136",
+              "display": "Certified Nursing Assistant (CNA) [Nursing Assistants]"
+            }
+          ],
+          "text": "Certified Nursing Assistant (CNA) [Nursing Assistants]"
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "86188-0",
+                  "display": "History of Occupation Industry"
+                }
+              ],
+              "text": "History of Occupation Industry"
+            },
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/PHOccupationalDataForHealthODH",
+                  "code": "621610.008495",
+                  "display": "Home nursing services"
+                }
+              ],
+              "text": "Home nursing services"
+            }
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-us-core-observation-occupation</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-us-core-blood-pressure"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-us-core-blood-pressure",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure|6.1.0"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure panel with all children optional"
+            }
+          ],
+          "text": "Blood pressure panel with all children optional"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectiveDateTime": "1999-07-02",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization"
+          }
+        ],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ],
+              "text": "Systolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 109,
+              "unit": "mmHg",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ],
+              "text": "Diastolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 44,
+              "unit": "mmHg",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-us-core-blood-pressure</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-us-core-bp-data-absent-reason"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-us-core-bp-data-absent-reason",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure|6.1.0"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure panel with all children optional"
+            }
+          ],
+          "text": "Blood pressure panel with all children optional"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectiveDateTime": "1999-07-03",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization"
+          }
+        ],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ],
+              "text": "Systolic blood pressure"
+            },
+            "dataAbsentReason": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/data-absent-reason",
+                  "code": "unknown",
+                  "display": "Unknown"
+                }
+              ],
+              "text": "Unknown"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ],
+              "text": "Diastolic blood pressure"
+            },
+            "dataAbsentReason": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/data-absent-reason",
+                  "code": "unknown",
+                  "display": "Unknown"
+                }
+              ],
+              "text": "Unknown"
+            }
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-us-core-bp-data-absent-reason</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-us-core-bmi"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-us-core-bmi",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi|6.1.0"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "39156-5",
+              "display": "Body mass index (BMI) [Ratio]"
+            }
+          ],
+          "text": "Body mass index (BMI) [Ratio]"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectiveDateTime": "1999-07-02",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization"
+          }
+        ],
+        "valueQuantity": {
+          "value": 16.2,
+          "unit": "kg/m2",
+          "system": "http://unitsofmeasure.org",
+          "code": "kg/m2"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-us-core-bmi</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-pediatric-bmi-for-age"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-pediatric-bmi-for-age",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age|6.1.0"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "59576-9",
+              "display": "Body mass index (BMI) [Percentile] Per age and sex"
+            }
+          ],
+          "text": "Body mass index (BMI) [Percentile] Per age and sex"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectiveDateTime": "2019-05-04T12:12:29-07:00",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization"
+          }
+        ],
+        "valueQuantity": {
+          "value": 65,
+          "unit": "%",
+          "system": "http://unitsofmeasure.org",
+          "code": "%"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-pediatric-bmi-for-age</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-us-core-body-height"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-us-core-body-height",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height|6.1.0"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "8302-2",
+              "display": "Body height"
+            }
+          ],
+          "text": "Body height"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectiveDateTime": "1999-07-02",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization"
+          }
+        ],
+        "valueQuantity": {
+          "value": 111.506,
+          "unit": "cm",
+          "system": "http://unitsofmeasure.org",
+          "code": "cm"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-us-core-body-height</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-us-core-body-temperature"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-us-core-body-temperature",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature|6.1.0"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "8310-5",
+              "display": "Body temperature"
+            }
+          ],
+          "text": "Body temperature"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectiveDateTime": "1999-07-02",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization"
+          }
+        ],
+        "valueQuantity": {
+          "value": 36.6,
+          "unit": "Cel",
+          "system": "http://unitsofmeasure.org",
+          "code": "Cel"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-us-core-body-temperature</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-us-core-body-weight"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-us-core-body-weight",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight|6.1.0"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "29463-7",
+              "display": "Body Weight"
+            }
+          ],
+          "text": "Body Weight"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectiveDateTime": "1999-07-02",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization"
+          }
+        ],
+        "valueQuantity": {
+          "value": 20.09,
+          "unit": "kg",
+          "system": "http://unitsofmeasure.org",
+          "code": "kg"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-us-core-body-weight</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-head-circumference-percentile"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-head-circumference-percentile",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile|6.1.0"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "8289-1",
+              "display": "Head Occipital-frontal circumference Percentile"
+            }
+          ],
+          "text": "Head Occipital-frontal circumference Percentile"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectiveDateTime": "2020-07-01",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization"
+          }
+        ],
+        "valueQuantity": {
+          "value": 82,
+          "unit": "%",
+          "system": "http://unitsofmeasure.org",
+          "code": "%"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-head-circumference-percentile</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-us-core-heart-rate"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-us-core-heart-rate",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate|6.1.0"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "8867-4",
+              "display": "Heart Rate"
+            }
+          ],
+          "text": "Heart Rate"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectiveDateTime": "1999-07-02",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization"
+          }
+        ],
+        "valueQuantity": {
+          "value": 44,
+          "unit": "beats/min",
+          "system": "http://unitsofmeasure.org",
+          "code": "/min"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-us-core-heart-rate</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-us-core-pulse-oximetry"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-us-core-pulse-oximetry",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry|6.1.0"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "59408-5",
+              "display": "Oxygen saturation in Arterial blood by Pulse oximetry"
+            },
+            {
+              "system": "http://loinc.org",
+              "code": "2708-6",
+              "display": "Oxygen saturation in Arterial blood"
+            }
+          ],
+          "text": "Oxygen saturation in Arterial blood by Pulse oximetry"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectiveDateTime": "1999-07-02",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization"
+          }
+        ],
+        "valueQuantity": {
+          "value": 99,
+          "unit": "%O2",
+          "system": "http://unitsofmeasure.org",
+          "code": "%"
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "3151-8",
+                  "display": "Inhaled oxygen flow rate"
+                }
+              ],
+              "text": "Inhaled oxygen flow rate"
+            },
+            "valueQuantity": {
+              "value": 2,
+              "unit": "L/min",
+              "system": "http://unitsofmeasure.org",
+              "code": "L/min"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "3150-0",
+                  "display": "Inhaled oxygen concentration"
+                }
+              ],
+              "text": "Inhaled oxygen concentration"
+            },
+            "valueQuantity": {
+              "value": 21,
+              "unit": "%",
+              "system": "http://unitsofmeasure.org",
+              "code": "%"
+            }
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-us-core-pulse-oximetry</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-us-core-respiratory-rate"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-us-core-respiratory-rate",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate|6.1.0"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "9279-1",
+              "display": "Respiratory rate"
+            }
+          ],
+          "text": "Respiratory rate"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectiveDateTime": "1999-07-02",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization"
+          }
+        ],
+        "valueQuantity": {
+          "value": 26,
+          "unit": "breaths per minute",
+          "system": "http://unitsofmeasure.org",
+          "code": "/min"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-us-core-respiratory-rate</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-pediatric-weight-for-height"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-pediatric-weight-for-height",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height|6.1.0"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "77606-2",
+              "display": "Weight-for-length Per age and sex"
+            }
+          ],
+          "text": "Weight-for-length Per age and sex"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectiveDateTime": "2020-07-02",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization"
+          }
+        ],
+        "valueQuantity": {
+          "value": 65,
+          "unit": "%",
+          "system": "http://unitsofmeasure.org",
+          "code": "%"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-pediatric-weight-for-height</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Provenance/usqualitycore-provenance"
+      },
+      "resource": {
+        "resourceType": "Provenance",
+        "id": "usqualitycore-provenance",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance|6.1.0"
+          ]
+        },
+        "target": [
+          {
+            "reference": "Patient/usqualitycore-patient"
+          },
+          {
+            "reference": "Specimen/usqualitycore-specimen"
+          },
+          {
+            "reference": "DocumentReference/usqualitycore-document-reference"
+          },
+          {
+            "reference": "Observation/usqualitycore-us-core-observation-pregnancyintent"
+          },
+          {
+            "reference": "Observation/usqualitycore-us-core-observation-pregnancystatus"
+          },
+          {
+            "reference": "Observation/usqualitycore-us-core-smokingstatus"
+          },
+          {
+            "reference": "Observation/usqualitycore-us-core-observation-occupation"
+          },
+          {
+            "reference": "Observation/usqualitycore-us-core-blood-pressure"
+          },
+          {
+            "reference": "Observation/usqualitycore-us-core-bp-data-absent-reason"
+          },
+          {
+            "reference": "Observation/usqualitycore-us-core-bmi"
+          },
+          {
+            "reference": "Observation/usqualitycore-pediatric-bmi-for-age"
+          },
+          {
+            "reference": "Observation/usqualitycore-us-core-body-height"
+          },
+          {
+            "reference": "Observation/usqualitycore-us-core-body-temperature"
+          },
+          {
+            "reference": "Observation/usqualitycore-us-core-body-weight"
+          },
+          {
+            "reference": "Observation/usqualitycore-head-circumference-percentile"
+          },
+          {
+            "reference": "Observation/usqualitycore-us-core-heart-rate"
+          },
+          {
+            "reference": "Observation/usqualitycore-us-core-pulse-oximetry"
+          },
+          {
+            "reference": "Observation/usqualitycore-us-core-respiratory-rate"
+          },
+          {
+            "reference": "Observation/usqualitycore-pediatric-weight-for-height"
+          },
+          {
+            "reference": "AdverseEvent/usqualitycore-adverse-event"
+          },
+          {
+            "reference": "AllergyIntolerance/usqualitycore-allergy-intolerance"
+          },
+          {
+            "reference": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup1"
+          },
+          {
+            "reference": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup10"
+          },
+          {
+            "reference": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup11"
+          },
+          {
+            "reference": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup12"
+          },
+          {
+            "reference": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup13"
+          },
+          {
+            "reference": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup14"
+          },
+          {
+            "reference": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup15"
+          },
+          {
+            "reference": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup16"
+          },
+          {
+            "reference": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup17"
+          },
+          {
+            "reference": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup18"
+          },
+          {
+            "reference": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup19"
+          },
+          {
+            "reference": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup2"
+          },
+          {
+            "reference": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup20"
+          },
+          {
+            "reference": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup3"
+          },
+          {
+            "reference": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup4"
+          },
+          {
+            "reference": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup5"
+          },
+          {
+            "reference": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup6"
+          },
+          {
+            "reference": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup7"
+          },
+          {
+            "reference": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup8"
+          },
+          {
+            "reference": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup9"
+          },
+          {
+            "reference": "CarePlan/usqualitycore-care-plan"
+          },
+          {
+            "reference": "CareTeam/usqualitycore-care-team"
+          },
+          {
+            "reference": "Condition/usqualitycore-condition-encounter-diagnosis"
+          },
+          {
+            "reference": "Condition/usqualitycore-condition-problems-health-concerns"
+          },
+          {
+            "reference": "Coverage/usqualitycore-coverage"
+          },
+          {
+            "reference": "Device/usqualitycore-device"
+          },
+          {
+            "reference": "DeviceRequest/usqualitycore-devicenotrequested"
+          },
+          {
+            "reference": "DeviceRequest/usqualitycore-devicerequest"
+          },
+          {
+            "reference": "DiagnosticReport/usqualitycore-diagnostic-report-lab"
+          },
+          {
+            "reference": "DiagnosticReport/usqualitycore-diagnostic-report-note"
+          },
+          {
+            "reference": "Encounter/usqualitycore-encounter"
+          },
+          {
+            "reference": "FamilyMemberHistory/usqualitycore-family-member-history"
+          },
+          {
+            "reference": "Goal/usqualitycore-goal"
+          },
+          {
+            "reference": "Group/usqualitycore-group"
+          },
+          {
+            "reference": "Immunization/usqualitycore-immunization"
+          },
+          {
+            "reference": "Immunization/usqualitycore-immunizationnotdone"
+          },
+          {
+            "reference": "Immunization/usqualitycore-immunizationnotdone-2"
+          },
+          {
+            "reference": "MedicationAdministration/usqualitycore-medicationadministration"
+          },
+          {
+            "reference": "MedicationAdministration/usqualitycore-medicationadministrationnotdone"
+          },
+          {
+            "reference": "MedicationDispense/usqualitycore-medicationdispense"
+          },
+          {
+            "reference": "MedicationDispense/usqualitycore-medicationdispensedeclined"
+          },
+          {
+            "reference": "MedicationRequest/usqualitycore-medicationnotrequested"
+          },
+          {
+            "reference": "MedicationRequest/usqualitycore-medicationrequest"
+          },
+          {
+            "reference": "Observation/usqualitycore-observation-clinical-result"
+          },
+          {
+            "reference": "Observation/usqualitycore-observation-clinical-result-2"
+          },
+          {
+            "reference": "Observation/usqualitycore-observation-clinical-result-3"
+          },
+          {
+            "reference": "Observation/usqualitycore-observation-clinical-result-4"
+          },
+          {
+            "reference": "Observation/usqualitycore-observation-lab"
+          },
+          {
+            "reference": "Observation/usqualitycore-observation-lab-2"
+          },
+          {
+            "reference": "Observation/usqualitycore-observation-lab-3"
+          },
+          {
+            "reference": "Observation/usqualitycore-observation-lab-4"
+          },
+          {
+            "reference": "Observation/usqualitycore-observation-screening-assessment"
+          },
+          {
+            "reference": "Observation/usqualitycore-observation-screening-assessment-2"
+          },
+          {
+            "reference": "Observation/usqualitycore-observation-screening-assessment-3"
+          },
+          {
+            "reference": "Observation/usqualitycore-observation-screening-assessment-4"
+          },
+          {
+            "reference": "Observation/usqualitycore-observationcancelled"
+          },
+          {
+            "reference": "Procedure/usqualitycore-procedure"
+          },
+          {
+            "reference": "Procedure/usqualitycore-procedurenotdone"
+          },
+          {
+            "reference": "QuestionnaireResponse/usqualitycore-questionnaire-response"
+          },
+          {
+            "reference": "RelatedPerson/usqualitycore-related-person"
+          },
+          {
+            "reference": "ServiceRequest/usqualitycore-servicenotrequested"
+          },
+          {
+            "reference": "ServiceRequest/usqualitycore-servicerequest"
+          },
+          {
+            "reference": "Observation/usqualitycore-simple-observation"
+          },
+          {
+            "reference": "Observation/usqualitycore-simple-observation-2"
+          },
+          {
+            "reference": "Observation/usqualitycore-simple-observation-3"
+          },
+          {
+            "reference": "Observation/usqualitycore-simple-observation-4"
+          },
+          {
+            "reference": "Task/usqualitycore-task"
+          },
+          {
+            "reference": "Task/usqualitycore-taskrejected"
+          },
+          {
+            "reference": "Task/usqualitycore-taskrejected-2"
+          }
+        ],
+        "recorded": "2015-02-15T16:30:00Z",
+        "agent": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code": "author",
+                  "display": "Author"
+                }
+              ]
+            },
+            "who": {
+              "reference": "Practitioner/usqualitycore-practitioner"
+            },
+            "onBehalfOf": {
+              "reference": "Organization/usqualitycore-organization"
+            }
+          },
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type",
+                  "code": "transmitter",
+                  "display": "Transmitter"
+                }
+              ]
+            },
+            "who": {
+              "reference": "Organization/usqualitycore-organization"
+            }
+          }
+        ],
+        "entity": [
+          {
+            "role": "source",
+            "what": {
+              "reference": "DocumentReference/usqualitycore-document-reference"
+            }
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-provenance</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "AdverseEvent/usqualitycore-adverse-event"
+      },
+      "resource": {
+        "resourceType": "AdverseEvent",
+        "id": "usqualitycore-adverse-event",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-adverseevent"
+          ]
+        },
+        "identifier": {
+          "system": "https://github.com/inferno-framework/ids/patients/risks",
+          "value": "49476534"
+        },
+        "actuality": "actual",
+        "event": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "725119006",
+              "display": "Generalized rash (disorder)"
+            }
+          ]
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/adverse-event-category",
+                "code": "clinical-research",
+                "display": "Clinical Research"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "detected": "2017-01-29T12:34:56+00:00",
+        "recordedDate": "2017-01-29T12:34:56+00:00",
+        "date": "2017-01-29T12:34:56+00:00",
+        "resultingCondition": [
+          {
+            "reference": "Condition/usqualitycore-condition-problems-health-concerns"
+          }
+        ],
+        "seriousness": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/adverse-event-seriousness",
+              "code": "non-serious",
+              "display": "Non-serious"
+            }
+          ]
+        },
+        "location": {
+          "reference": "Location/usqualitycore-location"
+        },
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "suspectEntity": [
+          {
+            "instance": {
+              "reference": "Medication/usqualitycore-medication"
+            },
+            "causality": [
+              {
+                "assessment": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/adverse-event-causality-assess",
+                      "code": "possible",
+                      "display": "Possible"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-adverse-event</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "AllergyIntolerance/usqualitycore-allergy-intolerance"
+      },
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "id": "usqualitycore-allergy-intolerance",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-allergyintolerance"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://github.com/inferno-framework/ids/patients/risks",
+            "value": "49476534"
+          }
+        ],
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed"
+            }
+          ]
+        },
+        "type": "allergy",
+        "category": [
+          "food"
+        ],
+        "criticality": "high",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "227493005",
+              "display": "Cashew nuts"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2004",
+        "recordedDate": "2014-10-09T14:58:00+11:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "asserter": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "lastOccurrence": "2012-06-02T01:45:31+00:00",
+        "note": [
+          {
+            "text": "The criticality is high becasue of the observed anaphylactic reaction when challenged with cashew extract."
+          }
+        ],
+        "reaction": [
+          {
+            "substance": {
+              "coding": [
+                {
+                  "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                  "code": "1160593",
+                  "display": "cashew nut allergenic extract Injectable Product"
+                }
+              ]
+            },
+            "manifestation": [
+              {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "39579001",
+                    "display": "Anaphylactic reaction"
+                  }
+                ]
+              }
+            ],
+            "description": "Challenge Protocol. Severe reaction to subcutaneous cashew extract. Epinephrine administered",
+            "onset": "2012-06-12",
+            "severity": "severe",
+            "exposureRoute": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "34206005",
+                  "display": "Subcutaneous route"
+                }
+              ]
+            }
+          },
+          {
+            "manifestation": [
+              {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "122003",
+                    "display": "Choroidal hemorrhage"
+                  }
+                ]
+              }
+            ],
+            "onset": "2004",
+            "severity": "moderate",
+            "note": [
+              {
+                "text": "The patient reports that the onset of urticaria was within 15 minutes of eating cashews."
+              }
+            ]
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-allergy-intolerance</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup1"
+      },
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "id": "usqualitycore-allergy-intolerance-dup1",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-allergyintolerance"
+          ]
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed"
+            }
+          ]
+        },
+        "type": "allergy",
+        "category": [
+          "food"
+        ],
+        "criticality": "high",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "227493005",
+              "display": "Cashew nuts"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2004",
+        "recordedDate": "2014-10-09T14:58:00+11:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "asserter": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "lastOccurrence": "2012-06-02T01:45:31+00:00",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-allergy-intolerance-dup1</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup10"
+      },
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-allergyintolerance"
+          ]
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed"
+            }
+          ]
+        },
+        "type": "allergy",
+        "category": [
+          "food"
+        ],
+        "criticality": "high",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "227493005",
+              "display": "Cashew nuts"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2004",
+        "recordedDate": "2014-10-09T14:58:00+11:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "asserter": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "lastOccurrence": "2012-06-02T01:45:31+00:00",
+        "id": "usqualitycore-allergy-intolerance-dup10",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-allergy-intolerance-dup10</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup11"
+      },
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-allergyintolerance"
+          ]
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed"
+            }
+          ]
+        },
+        "type": "allergy",
+        "category": [
+          "food"
+        ],
+        "criticality": "high",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "227493005",
+              "display": "Cashew nuts"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2004",
+        "recordedDate": "2014-10-09T14:58:00+11:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "asserter": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "lastOccurrence": "2012-06-02T01:45:31+00:00",
+        "id": "usqualitycore-allergy-intolerance-dup11",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-allergy-intolerance-dup11</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup12"
+      },
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-allergyintolerance"
+          ]
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed"
+            }
+          ]
+        },
+        "type": "allergy",
+        "category": [
+          "food"
+        ],
+        "criticality": "high",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "227493005",
+              "display": "Cashew nuts"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2004",
+        "recordedDate": "2014-10-09T14:58:00+11:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "asserter": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "lastOccurrence": "2012-06-02T01:45:31+00:00",
+        "id": "usqualitycore-allergy-intolerance-dup12",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-allergy-intolerance-dup12</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup13"
+      },
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-allergyintolerance"
+          ]
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed"
+            }
+          ]
+        },
+        "type": "allergy",
+        "category": [
+          "food"
+        ],
+        "criticality": "high",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "227493005",
+              "display": "Cashew nuts"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2004",
+        "recordedDate": "2014-10-09T14:58:00+11:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "asserter": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "lastOccurrence": "2012-06-02T01:45:31+00:00",
+        "id": "usqualitycore-allergy-intolerance-dup13",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-allergy-intolerance-dup13</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup14"
+      },
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-allergyintolerance"
+          ]
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed"
+            }
+          ]
+        },
+        "type": "allergy",
+        "category": [
+          "food"
+        ],
+        "criticality": "high",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "227493005",
+              "display": "Cashew nuts"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2004",
+        "recordedDate": "2014-10-09T14:58:00+11:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "asserter": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "lastOccurrence": "2012-06-02T01:45:31+00:00",
+        "id": "usqualitycore-allergy-intolerance-dup14",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-allergy-intolerance-dup14</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup15"
+      },
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-allergyintolerance"
+          ]
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed"
+            }
+          ]
+        },
+        "type": "allergy",
+        "category": [
+          "food"
+        ],
+        "criticality": "high",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "227493005",
+              "display": "Cashew nuts"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2004",
+        "recordedDate": "2014-10-09T14:58:00+11:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "asserter": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "lastOccurrence": "2012-06-02T01:45:31+00:00",
+        "id": "usqualitycore-allergy-intolerance-dup15",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-allergy-intolerance-dup15</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup16"
+      },
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-allergyintolerance"
+          ]
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed"
+            }
+          ]
+        },
+        "type": "allergy",
+        "category": [
+          "food"
+        ],
+        "criticality": "high",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "227493005",
+              "display": "Cashew nuts"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2004",
+        "recordedDate": "2014-10-09T14:58:00+11:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "asserter": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "lastOccurrence": "2012-06-02T01:45:31+00:00",
+        "id": "usqualitycore-allergy-intolerance-dup16",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-allergy-intolerance-dup16</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup17"
+      },
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-allergyintolerance"
+          ]
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed"
+            }
+          ]
+        },
+        "type": "allergy",
+        "category": [
+          "food"
+        ],
+        "criticality": "high",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "227493005",
+              "display": "Cashew nuts"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2004",
+        "recordedDate": "2014-10-09T14:58:00+11:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "asserter": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "lastOccurrence": "2012-06-02T01:45:31+00:00",
+        "id": "usqualitycore-allergy-intolerance-dup17",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-allergy-intolerance-dup17</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup18"
+      },
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-allergyintolerance"
+          ]
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed"
+            }
+          ]
+        },
+        "type": "allergy",
+        "category": [
+          "food"
+        ],
+        "criticality": "high",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "227493005",
+              "display": "Cashew nuts"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2004",
+        "recordedDate": "2014-10-09T14:58:00+11:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "asserter": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "lastOccurrence": "2012-06-02T01:45:31+00:00",
+        "id": "usqualitycore-allergy-intolerance-dup18",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-allergy-intolerance-dup18</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup19"
+      },
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-allergyintolerance"
+          ]
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed"
+            }
+          ]
+        },
+        "type": "allergy",
+        "category": [
+          "food"
+        ],
+        "criticality": "high",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "227493005",
+              "display": "Cashew nuts"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2004",
+        "recordedDate": "2014-10-09T14:58:00+11:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "asserter": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "lastOccurrence": "2012-06-02T01:45:31+00:00",
+        "id": "usqualitycore-allergy-intolerance-dup19",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-allergy-intolerance-dup19</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup2"
+      },
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "id": "usqualitycore-allergy-intolerance-dup2",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-allergyintolerance"
+          ]
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed"
+            }
+          ]
+        },
+        "type": "allergy",
+        "category": [
+          "food"
+        ],
+        "criticality": "high",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "227493005",
+              "display": "Cashew nuts"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2004",
+        "recordedDate": "2014-10-09T14:58:00+11:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "asserter": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "lastOccurrence": "2012-06-02T01:45:31+00:00",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-allergy-intolerance-dup2</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup20"
+      },
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-allergyintolerance"
+          ]
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed"
+            }
+          ]
+        },
+        "type": "allergy",
+        "category": [
+          "food"
+        ],
+        "criticality": "high",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "227493005",
+              "display": "Cashew nuts"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2004",
+        "recordedDate": "2014-10-09T14:58:00+11:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "asserter": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "lastOccurrence": "2012-06-02T01:45:31+00:00",
+        "id": "usqualitycore-allergy-intolerance-dup20",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-allergy-intolerance-dup20</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup3"
+      },
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "id": "usqualitycore-allergy-intolerance-dup3",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-allergyintolerance"
+          ]
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed"
+            }
+          ]
+        },
+        "type": "allergy",
+        "category": [
+          "food"
+        ],
+        "criticality": "high",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "227493005",
+              "display": "Cashew nuts"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2004",
+        "recordedDate": "2014-10-09T14:58:00+11:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "asserter": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "lastOccurrence": "2012-06-02T01:45:31+00:00",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-allergy-intolerance-dup3</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup4"
+      },
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-allergyintolerance"
+          ]
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed"
+            }
+          ]
+        },
+        "type": "allergy",
+        "category": [
+          "food"
+        ],
+        "criticality": "high",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "227493005",
+              "display": "Cashew nuts"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2004",
+        "recordedDate": "2014-10-09T14:58:00+11:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "asserter": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "lastOccurrence": "2012-06-02T01:45:31+00:00",
+        "id": "usqualitycore-allergy-intolerance-dup4",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-allergy-intolerance-dup4</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup5"
+      },
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-allergyintolerance"
+          ]
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed"
+            }
+          ]
+        },
+        "type": "allergy",
+        "category": [
+          "food"
+        ],
+        "criticality": "high",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "227493005",
+              "display": "Cashew nuts"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2004",
+        "recordedDate": "2014-10-09T14:58:00+11:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "asserter": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "lastOccurrence": "2012-06-02T01:45:31+00:00",
+        "id": "usqualitycore-allergy-intolerance-dup5",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-allergy-intolerance-dup5</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup6"
+      },
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-allergyintolerance"
+          ]
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed"
+            }
+          ]
+        },
+        "type": "allergy",
+        "category": [
+          "food"
+        ],
+        "criticality": "high",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "227493005",
+              "display": "Cashew nuts"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2004",
+        "recordedDate": "2014-10-09T14:58:00+11:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "asserter": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "lastOccurrence": "2012-06-02T01:45:31+00:00",
+        "id": "usqualitycore-allergy-intolerance-dup6",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-allergy-intolerance-dup6</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup7"
+      },
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-allergyintolerance"
+          ]
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed"
+            }
+          ]
+        },
+        "type": "allergy",
+        "category": [
+          "food"
+        ],
+        "criticality": "high",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "227493005",
+              "display": "Cashew nuts"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2004",
+        "recordedDate": "2014-10-09T14:58:00+11:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "asserter": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "lastOccurrence": "2012-06-02T01:45:31+00:00",
+        "id": "usqualitycore-allergy-intolerance-dup7",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-allergy-intolerance-dup7</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup8"
+      },
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-allergyintolerance"
+          ]
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed"
+            }
+          ]
+        },
+        "type": "allergy",
+        "category": [
+          "food"
+        ],
+        "criticality": "high",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "227493005",
+              "display": "Cashew nuts"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2004",
+        "recordedDate": "2014-10-09T14:58:00+11:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "asserter": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "lastOccurrence": "2012-06-02T01:45:31+00:00",
+        "id": "usqualitycore-allergy-intolerance-dup8",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-allergy-intolerance-dup8</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "AllergyIntolerance/usqualitycore-allergy-intolerance-dup9"
+      },
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-allergyintolerance"
+          ]
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              "code": "confirmed"
+            }
+          ]
+        },
+        "type": "allergy",
+        "category": [
+          "food"
+        ],
+        "criticality": "high",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "227493005",
+              "display": "Cashew nuts"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2004",
+        "recordedDate": "2014-10-09T14:58:00+11:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "asserter": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "lastOccurrence": "2012-06-02T01:45:31+00:00",
+        "id": "usqualitycore-allergy-intolerance-dup9",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-allergy-intolerance-dup9</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "CarePlan/usqualitycore-care-plan"
+      },
+      "resource": {
+        "resourceType": "CarePlan",
+        "id": "usqualitycore-care-plan",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p class=\"res-header-id\"><b>Generated Narrative: CarePlan example</b></p><a name=\"example\"> </a><a name=\"hcexample\"> </a><p><b>instantiatesCanonical</b>: <code>http://fhir.org/guides/who/anc-cds/PlanDefinition/anc-contact-schedule</code></p><p><b>status</b>: Active</p><p><b>intent</b>: Plan</p><p><b>category</b>: <span title=\"Codes:{http://hl7.org/fhir/us/core/CodeSystem/careplan-category assess-plan}\">Assessment and Plan of Treatment</span></p><p><b>subject</b>: Eve Everywoman</p><p><b>period</b>: 2019-05-24 --&gt; 2020-02-24</p><p><b>careTeam</b>: <a href=\"CareTeam-example.html\">CareTeam: status = active</a></p><p><b>addresses</b>: pregnancy</p><p><b>goal</b>: pregnancy goal</p><blockquote><p><b>activity</b></p><p><b>outcomeReference</b>: First contact, occurred at about 12 weeks based on gestational age from LMP of 2019-03-01</p><h3>Details</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Kind</b></td><td><b>InstantiatesCanonical</b></td><td><b>Code</b></td><td><b>Status</b></td><td><b>Performer</b></td><td><b>Description</b></td></tr><tr><td style=\"display: none\">*</td><td>ServiceRequest</td><td><code>http://fhir.org/guides/who/anc-cds/PlanDefinition/anc-contact</code></td><td><span title=\"Codes:{http://snomed.info/sct 424525001}\">Antenatal care</span></td><td>In Progress</td><td>Mabel Midwife</td><td>First antenatal care contact</td></tr></table></blockquote><blockquote><p><b>activity</b></p><h3>Details</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Kind</b></td><td><b>InstantiatesCanonical</b></td><td><b>Code</b></td><td><b>Status</b></td><td><b>Scheduled[x]</b></td><td><b>Performer</b></td><td><b>Description</b></td></tr><tr><td style=\"display: none\">*</td><td>ServiceRequest</td><td><code>http://fhir.org/guides/who/anc-cds/PlanDefinition/anc-contact</code></td><td><span title=\"Codes:{http://snomed.info/sct 424525001}\">Antenatal care</span></td><td>Scheduled</td><td>2019-07-26 --&gt; (ongoing)</td><td>Mabel Midwife</td><td>Second contact to occur at 20 weeks of gestational age</td></tr></table></blockquote><blockquote><p><b>activity</b></p><h3>Details</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Kind</b></td><td><b>InstantiatesCanonical</b></td><td><b>Code</b></td><td><b>Status</b></td><td><b>Scheduled[x]</b></td><td><b>Performer</b></td><td><b>Description</b></td></tr><tr><td style=\"display: none\">*</td><td>ServiceRequest</td><td><code>http://fhir.org/guides/who/anc-cds/PlanDefinition/anc-contact</code></td><td><span title=\"Codes:{http://snomed.info/sct 424525001}\">Antenatal care</span></td><td>Not Started</td><td>2019-09-06 --&gt; (ongoing)</td><td>Mabel Midwife</td><td>Third contact to occur at 26 weeks of gestational age</td></tr></table></blockquote><blockquote><p><b>activity</b></p><h3>Details</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Kind</b></td><td><b>InstantiatesCanonical</b></td><td><b>Code</b></td><td><b>Status</b></td><td><b>Scheduled[x]</b></td><td><b>Performer</b></td><td><b>Description</b></td></tr><tr><td style=\"display: none\">*</td><td>ServiceRequest</td><td><code>http://fhir.org/guides/who/anc-cds/PlanDefinition/anc-contact</code></td><td><span title=\"Codes:{http://snomed.info/sct 424525001}\">Antenatal care</span></td><td>Not Started</td><td>2019-10-04 --&gt; (ongoing)</td><td>Mabel Midwife</td><td>Fourth contact to occur at 30 weeks of gestational age</td></tr></table></blockquote><blockquote><p><b>activity</b></p><h3>Details</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Kind</b></td><td><b>InstantiatesCanonical</b></td><td><b>Code</b></td><td><b>Status</b></td><td><b>Scheduled[x]</b></td><td><b>Performer</b></td><td><b>Description</b></td></tr><tr><td style=\"display: none\">*</td><td>ServiceRequest</td><td><code>http://fhir.org/guides/who/anc-cds/PlanDefinition/anc-contact</code></td><td><span title=\"Codes:{http://snomed.info/sct 424525001}\">Antenatal care</span></td><td>Not Started</td><td>2019-11-01 --&gt; (ongoing)</td><td>Mabel Midwife</td><td>Fifth contact to occur at 34 weeks of gestational age</td></tr></table></blockquote><blockquote><p><b>activity</b></p><h3>Details</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Kind</b></td><td><b>InstantiatesCanonical</b></td><td><b>Code</b></td><td><b>Status</b></td><td><b>Scheduled[x]</b></td><td><b>Performer</b></td><td><b>Description</b></td></tr><tr><td style=\"display: none\">*</td><td>ServiceRequest</td><td><code>http://fhir.org/guides/who/anc-cds/PlanDefinition/anc-contact</code></td><td><span title=\"Codes:{http://snomed.info/sct 424525001}\">Antenatal care</span></td><td>Not Started</td><td>2019-11-15 --&gt; (ongoing)</td><td>Mabel Midwife</td><td>Sixth contact to occur at 36 weeks of gestational age</td></tr></table></blockquote><blockquote><p><b>activity</b></p><h3>Details</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Kind</b></td><td><b>InstantiatesCanonical</b></td><td><b>Code</b></td><td><b>Status</b></td><td><b>Scheduled[x]</b></td><td><b>Performer</b></td><td><b>Description</b></td></tr><tr><td style=\"display: none\">*</td><td>ServiceRequest</td><td><code>http://fhir.org/guides/who/anc-cds/PlanDefinition/anc-contact</code></td><td><span title=\"Codes:{http://snomed.info/sct 424525001}\">Antenatal care</span></td><td>Not Started</td><td>2019-11-29 --&gt; (ongoing)</td><td>Mabel Midwife</td><td>Seventh contact to occur at 38 weeks of gestational age</td></tr></table></blockquote><blockquote><p><b>activity</b></p><h3>Details</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Kind</b></td><td><b>InstantiatesCanonical</b></td><td><b>Code</b></td><td><b>Status</b></td><td><b>Scheduled[x]</b></td><td><b>Performer</b></td><td><b>Description</b></td></tr><tr><td style=\"display: none\">*</td><td>ServiceRequest</td><td><code>http://fhir.org/guides/who/anc-cds/PlanDefinition/anc-contact</code></td><td><span title=\"Codes:{http://snomed.info/sct 424525001}\">Antenatal care</span></td><td>Not Started</td><td>2019-12-13 --&gt; (ongoing)</td><td>Mabel Midwife</td><td>Eighth contact to occur at 40 weeks of gestational age</td></tr></table></blockquote><blockquote><p><b>activity</b></p><h3>Details</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Kind</b></td><td><b>Code</b></td><td><b>Status</b></td><td><b>Scheduled[x]</b></td><td><b>Performer</b></td><td><b>Description</b></td></tr><tr><td style=\"display: none\">*</td><td>ServiceRequest</td><td><span title=\"Codes:{http://snomed.info/sct 236973005}\">Delivery procedure</span></td><td>Not Started</td><td>2019-12-13 --&gt; 2019-12-27</td><td>Mabel Midwife</td><td>Delivery</td></tr></table></blockquote></div>"
+        },
+        "instantiatesCanonical": [
+          "http://fhir.org/guides/who/anc-cds/PlanDefinition/anc-contact-schedule"
+        ],
+        "status": "active",
+        "intent": "plan",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/careplan-category",
+                "code": "assess-plan",
+                "display": "Assessment and Plan of Treatment"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "period": {
+          "start": "2019-05-24",
+          "end": "2020-02-24"
+        },
+        "careTeam": [
+          {
+            "reference": "CareTeam/usqualitycore-care-team"
+          }
+        ],
+        "addresses": [
+          {
+            "display": "pregnancy"
+          }
+        ],
+        "goal": [
+          {
+            "display": "pregnancy goal"
+          }
+        ],
+        "activity": [
+          {
+            "outcomeReference": [
+              {
+                "display": "First contact, occurred at about 12 weeks based on gestational age from LMP of 2019-03-01"
+              }
+            ],
+            "detail": {
+              "kind": "ServiceRequest",
+              "instantiatesCanonical": [
+                "http://fhir.org/guides/who/anc-cds/PlanDefinition/anc-contact"
+              ],
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "424525001",
+                    "display": "Antenatal care (regime/therapy)"
+                  }
+                ],
+                "text": "Antenatal care"
+              },
+              "status": "in-progress",
+              "performer": [
+                {
+                  "display": "Mabel Midwife"
+                }
+              ],
+              "description": "First antenatal care contact"
+            }
+          },
+          {
+            "detail": {
+              "kind": "ServiceRequest",
+              "instantiatesCanonical": [
+                "http://fhir.org/guides/who/anc-cds/PlanDefinition/anc-contact"
+              ],
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "424525001",
+                    "display": "Antenatal care (regime/therapy)"
+                  }
+                ],
+                "text": "Antenatal care"
+              },
+              "status": "scheduled",
+              "scheduledPeriod": {
+                "start": "2019-07-26"
+              },
+              "performer": [
+                {
+                  "display": "Mabel Midwife"
+                }
+              ],
+              "description": "Second contact to occur at 20 weeks of gestational age"
+            }
+          },
+          {
+            "detail": {
+              "kind": "ServiceRequest",
+              "instantiatesCanonical": [
+                "http://fhir.org/guides/who/anc-cds/PlanDefinition/anc-contact"
+              ],
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "424525001",
+                    "display": "Antenatal care (regime/therapy)"
+                  }
+                ],
+                "text": "Antenatal care"
+              },
+              "status": "not-started",
+              "scheduledPeriod": {
+                "start": "2019-09-06"
+              },
+              "performer": [
+                {
+                  "display": "Mabel Midwife"
+                }
+              ],
+              "description": "Third contact to occur at 26 weeks of gestational age"
+            }
+          },
+          {
+            "detail": {
+              "kind": "ServiceRequest",
+              "instantiatesCanonical": [
+                "http://fhir.org/guides/who/anc-cds/PlanDefinition/anc-contact"
+              ],
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "424525001",
+                    "display": "Antenatal care (regime/therapy)"
+                  }
+                ],
+                "text": "Antenatal care"
+              },
+              "status": "not-started",
+              "scheduledPeriod": {
+                "start": "2019-10-04"
+              },
+              "performer": [
+                {
+                  "display": "Mabel Midwife"
+                }
+              ],
+              "description": "Fourth contact to occur at 30 weeks of gestational age"
+            }
+          },
+          {
+            "detail": {
+              "kind": "ServiceRequest",
+              "instantiatesCanonical": [
+                "http://fhir.org/guides/who/anc-cds/PlanDefinition/anc-contact"
+              ],
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "424525001",
+                    "display": "Antenatal care (regime/therapy)"
+                  }
+                ],
+                "text": "Antenatal care"
+              },
+              "status": "not-started",
+              "scheduledPeriod": {
+                "start": "2019-11-01"
+              },
+              "performer": [
+                {
+                  "display": "Mabel Midwife"
+                }
+              ],
+              "description": "Fifth contact to occur at 34 weeks of gestational age"
+            }
+          },
+          {
+            "detail": {
+              "kind": "ServiceRequest",
+              "instantiatesCanonical": [
+                "http://fhir.org/guides/who/anc-cds/PlanDefinition/anc-contact"
+              ],
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "424525001",
+                    "display": "Antenatal care (regime/therapy)"
+                  }
+                ],
+                "text": "Antenatal care"
+              },
+              "status": "not-started",
+              "scheduledPeriod": {
+                "start": "2019-11-15"
+              },
+              "performer": [
+                {
+                  "display": "Mabel Midwife"
+                }
+              ],
+              "description": "Sixth contact to occur at 36 weeks of gestational age"
+            }
+          },
+          {
+            "detail": {
+              "kind": "ServiceRequest",
+              "instantiatesCanonical": [
+                "http://fhir.org/guides/who/anc-cds/PlanDefinition/anc-contact"
+              ],
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "424525001",
+                    "display": "Antenatal care (regime/therapy)"
+                  }
+                ],
+                "text": "Antenatal care"
+              },
+              "status": "not-started",
+              "scheduledPeriod": {
+                "start": "2019-11-29"
+              },
+              "performer": [
+                {
+                  "display": "Mabel Midwife"
+                }
+              ],
+              "description": "Seventh contact to occur at 38 weeks of gestational age"
+            }
+          },
+          {
+            "detail": {
+              "kind": "ServiceRequest",
+              "instantiatesCanonical": [
+                "http://fhir.org/guides/who/anc-cds/PlanDefinition/anc-contact"
+              ],
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "424525001",
+                    "display": "Antenatal care (regime/therapy)"
+                  }
+                ],
+                "text": "Antenatal care"
+              },
+              "status": "not-started",
+              "scheduledPeriod": {
+                "start": "2019-12-13"
+              },
+              "performer": [
+                {
+                  "display": "Mabel Midwife"
+                }
+              ],
+              "description": "Eighth contact to occur at 40 weeks of gestational age"
+            }
+          },
+          {
+            "detail": {
+              "kind": "ServiceRequest",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "236973005",
+                    "display": "Delivery procedure (procedure)"
+                  }
+                ],
+                "text": "Delivery procedure"
+              },
+              "status": "not-started",
+              "scheduledPeriod": {
+                "start": "2019-12-13",
+                "end": "2019-12-27"
+              },
+              "performer": [
+                {
+                  "display": "Mabel Midwife"
+                }
+              ],
+              "description": "Delivery"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "CareTeam/usqualitycore-care-team"
+      },
+      "resource": {
+        "resourceType": "CareTeam",
+        "id": "usqualitycore-care-team",
+        "status": "active",
+        "subject": {
+          "reference": "Patient/usqualitycore-patient",
+          "display": "Eve Everywoman"
+        },
+        "participant": [
+          {
+            "role": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationFunction",
+                    "code": "MDWF",
+                    "display": "midwife"
+                  }
+                ]
+              }
+            ],
+            "member": {
+              "reference": "Practitioner/usqualitycore-practitioner"
+            }
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-care-team</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Condition/usqualitycore-condition-encounter-diagnosis"
+      },
+      "resource": {
+        "resourceType": "Condition",
+        "id": "usqualitycore-condition-encounter-diagnosis",
+        "meta": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/instance-name",
+              "valueString": "Encounter Diagnosis Example"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/instance-description",
+              "valueMarkdown": "This example of a US Quality Core Condition Encounter Diagnosis Profile illustrates its use to capture information about a patient's encounter diagnosis."
+            }
+          ],
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-condition-encounter-diagnosis"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/condition-assertedDate",
+            "valueDateTime": "2007-12-14"
+          }
+        ],
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "inactive",
+              "display": "Inactive"
+            }
+          ],
+          "text": "Inactive"
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+              "code": "confirmed",
+              "display": "Confirmed"
+            }
+          ],
+          "text": "Confirmed"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "problem-list-item"
+              }
+            ]
+          },
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "encounter-diagnosis"
+              }
+            ]
+          }
+        ],
+        "severity": {
+          "coding": [
+            {
+              "system": "http://www.snomed.org/",
+              "code": "255604002",
+              "display": "Mild"
+            }
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "247824007",
+              "display": "Fear of becoming fat"
+            }
+          ],
+          "text": "Fear of becoming fat"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2007-12-14",
+        "abatementDateTime": "2007-12-21",
+        "recordedDate": "2007-12-14T07:15:07-08:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-condition-encounter-diagnosis</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Condition/usqualitycore-condition-problems-health-concerns"
+      },
+      "resource": {
+        "resourceType": "Condition",
+        "id": "usqualitycore-condition-problems-health-concerns",
+        "meta": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/instance-name",
+              "valueString": "Health Concern Example"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/instance-description",
+              "valueMarkdown": "This example of a US Quality Core Condition Problems and Health Concerns Profile illustrates its use to capture information about a patient's health concern."
+            }
+          ],
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-condition-problems-health-concerns"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/condition-assertedDate",
+            "valueDateTime": "2007-12-14"
+          }
+        ],
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "inactive",
+              "display": "Inactive"
+            }
+          ],
+          "text": "Inactive"
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+              "code": "confirmed",
+              "display": "Confirmed"
+            }
+          ],
+          "text": "Confirmed"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "problem-list-item"
+              }
+            ]
+          },
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "encounter-diagnosis"
+              }
+            ]
+          },
+          {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
+                "code": "functional-status",
+                "display": "Functional Status"
+              }
+            ],
+            "text": "Functional Status"
+          }
+        ],
+        "severity": {
+          "coding": [
+            {
+              "system": "http://www.snomed.org/",
+              "code": "255604002",
+              "display": "Mild"
+            }
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "247824007",
+              "display": "Fear of becoming fat"
+            }
+          ],
+          "text": "Fear of becoming fat"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "onsetDateTime": "2007-12-14",
+        "abatementDateTime": "2007-12-21",
+        "recordedDate": "2007-12-14T07:15:07-08:00",
+        "recorder": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-condition-problems-health-concerns</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Coverage/usqualitycore-coverage"
+      },
+      "resource": {
+        "resourceType": "Coverage",
+        "id": "usqualitycore-coverage",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-coverage"
+          ]
+        },
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "MB"
+                }
+              ]
+            }
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "https://nahdo.org/sopt",
+              "code": "59",
+              "display": "Other Private Insurance"
+            }
+          ]
+        },
+        "policyHolder": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "subscriber": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "subscriberId": "12191",
+        "beneficiary": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "dependent": "0",
+        "relationship": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/subscriber-relationship",
+              "code": "self"
+            }
+          ]
+        },
+        "period": {
+          "start": "2011-05-23",
+          "end": "2012-05-23"
+        },
+        "payor": [
+          {
+            "reference": "Organization/usqualitycore-organization"
+          }
+        ],
+        "class": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                  "code": "group",
+                  "display": "Group"
+                }
+              ]
+            },
+            "value": "Group",
+            "name": "US Quality Core Test Coverage Group"
+          },
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                  "code": "plan",
+                  "display": "Plan"
+                }
+              ]
+            },
+            "value": "Plan",
+            "name": "US Quality Core Test Coverage Plan"
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-coverage</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Device/usqualitycore-device"
+      },
+      "resource": {
+        "resourceType": "Device",
+        "id": "usqualitycore-device",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-device"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "http://goodcare.org/devices/id",
+            "value": "345675"
+          },
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "SNO"
+                }
+              ],
+              "text": "Serial Number"
+            },
+            "value": "AMID-342135-8464"
+          }
+        ],
+        "udiCarrier": [
+          {
+            "deviceIdentifier": "09504000059118",
+            "carrierHRF": "(01)09504000059118(17)141120(10)7654321D(21)10987654d321"
+          }
+        ],
+        "status": "active",
+        "manufacturer": "Acme Devices, Inc",
+        "lotNumber": "43453424",
+        "modelNumber": "AB 45-J",
+        "type": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "86184003",
+              "display": "Electrocardiographic monitor and recorder"
+            }
+          ],
+          "text": "ECG"
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "contact": [
+          {
+            "system": "phone",
+            "value": "ext 4352"
+          }
+        ],
+        "note": [
+          {
+            "authorReference": {
+              "reference": "Practitioner/usqualitycore-practitioner"
+            },
+            "time": "2015-06-28T14:03:32+10:00",
+            "text": "QA Checked"
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-device</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "DeviceRequest/usqualitycore-devicenotrequested"
+      },
+      "resource": {
+        "resourceType": "DeviceRequest",
+        "id": "usqualitycore-devicenotrequested",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-devicenotrequested"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-doNotPerformReason",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "410534003",
+                  "display": "Not indicated (qualifier value)"
+                }
+              ]
+            }
+          }
+        ],
+        "modifierExtension": [
+          {
+            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-DeviceRequest.doNotPerform",
+            "valueBoolean": true
+          }
+        ],
+        "status": "completed",
+        "intent": "original-order",
+        "codeCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "86184003",
+              "display": "Electrocardiographic monitor and recorder"
+            }
+          ],
+          "text": "ECG"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "authoredOn": "2015-03-25T19:32:52-05:00",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-devicerequest</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "DeviceRequest/usqualitycore-devicerequest"
+      },
+      "resource": {
+        "resourceType": "DeviceRequest",
+        "id": "usqualitycore-devicerequest",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-devicerequest"
+          ]
+        },
+        "modifierExtension": [
+          {
+            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-DeviceRequest.doNotPerform",
+            "valueBoolean": false
+          }
+        ],
+        "status": "completed",
+        "intent": "original-order",
+        "codeCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "86184003",
+              "display": "Electrocardiographic monitor and recorder"
+            }
+          ],
+          "text": "ECG"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "authoredOn": "2015-03-25T19:32:52-05:00",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-devicerequest</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "DiagnosticReport/usqualitycore-diagnostic-report-lab"
+      },
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "usqualitycore-diagnostic-report-lab",
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "LAB",
+                "display": "Laboratory"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "58410-2",
+              "display": "CBC panel - Blood by Automated count"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient",
+          "display": "Peter Chalmers"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectiveDateTime": "2005-07-05",
+        "issued": "2005-07-06T11:45:33+11:00",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization"
+          }
+        ],
+        "resultsInterpreter": [
+          {
+            "reference": "Practitioner/usqualitycore-practitioner"
+          }
+        ],
+        "result": [
+          {
+            "reference": "Observation/usqualitycore-observation-lab"
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-diagnostic-report-lab</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "DiagnosticReport/usqualitycore-diagnostic-report-note"
+      },
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "usqualitycore-diagnostic-report-note",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-diagnosticreport-note"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "code": "LP29684-5",
+                "display": "Radiology"
+              },
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "RAD",
+                "display": "Radiology"
+              }
+            ],
+            "text": "Radiology"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "30746-2",
+              "display": "Portable XR Chest Views"
+            }
+          ],
+          "text": "Portable XR Chest Views"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectiveDateTime": "2005-07-05",
+        "issued": "2005-07-06T11:45:33+11:00",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization"
+          }
+        ],
+        "resultsInterpreter": [
+          {
+            "reference": "Practitioner/usqualitycore-practitioner"
+          }
+        ],
+        "result": [
+          {
+            "reference": "Observation/usqualitycore-observation-lab"
+          }
+        ],
+        "media": [
+          {
+            "link": {
+              "reference": "Media/usqualitycore-r4-media"
+            }
+          }
+        ],
+        "presentedForm": [
+          {
+            "contentType": "application/xhtml",
+            "data": "PCFET0NUWVBFIGh0bWwgUFVCTElDICItLy9XM0MvL0RURCBYSFRNTCAxLjAgVHJhbnNpdGlvbmFsLy9FTiIgIkRURC94aHRtbDEtdHJhbnNpdGlvbmFsLmR0ZCI+CgkJPGh0bWwgeG1sOmxhbmc9ImVuIiBsYW5nPSJlbiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGh0bWwiPgkJCiAgPGhlYWQ+CiAgICA8dGl0bGU+Q2hlc3QgUG9ydGFibGU8L3RpdGxlPgogIDwvaGVhZD4KICA8Ym9keT4KICAgIDxwPlJlc3VsdDwvcD4KICAgIDxici8+Q2hlc3QgUG9ydGFibGUgCiAgICAgIAogICAgICA8cD5JTkRJQ0FUSU9OL0NMSU5JQ0FMIFFVRVNUSU9OOiBGZXZlciAvIFBuZXVtb25pYTwvcD4KICAgICAgCiAgICAgIDxwPkNPTVBBUklTT046IE5vbmUuPC9wPgogICAgICAKICAgICAgPHA+RklORElOR1M6PC9wPgogICAgICAKICAgICAgPHA+TElORVMgQU5EIFRVQkVTOiBOb25lLjwvcD4KICAgICAgCiAgICAgIDxwPkxVTkdTIEFORCBQTEVVUkE6PC9wPgogICAgICA8YnIvPkNsZWFyIGx1bmdzLiBOb3JtYWwgcHVsbW9uYXJ5IHZhc2N1bGFyaXR5LgogICAgICA8YnIvPk5vIHBsZXVyYWwgZWZmdXNpb24uCiAgICAgIDxici8+Tm8gcG5ldW1vdGhvcmF4LgogICAgICAKICAgICAgPHA+SEVBUlQsIE1FRElBU1RJTlVNIEFORCBISUxBOjwvcD4KICAgICAgPGJyLz5IZWFydCBpcyBub3JtYWwgaW4gc2l6ZS4KICAgICAgPGJyLz5Ob3JtYWwgbWVkaWFzdGluYWwgYW5kIGhpbGFyIGNvbnRvdXIuCiAgICAgIAogICAgICA8cD5CT05FUyBBTkQgU09GVCBUSVNTVUVTOjwvcD4KICAgICAgPGJyLz5ObyBhY3V0ZSBhYm5vcm1hbGl0eS4KICAgICAgCiAgICAgIDxwPklNUFJFU1NJT046PC9wPgogICAgICA8YnIvPk5vIGFjdXRlIGFibm9ybWFsaXR5LgogICAgICAKICAgICAgPHA+V1NOOiBPMTlJQy1TQy0wMjExPC9wPgogICAgICAKICAgICAgPHA+RGljdGF0ZWQgQnk6IEN1cmUgTUQsIENocmlzdGluZSBKCiAgICAgICAgRGljdGF0ZWQgRGF0ZS9UaW1lOiAwMi8wMy8xOSA3OjQ0IHBtCiAgICAgICAgUmV2aWV3ZWQgQnk6IEN1cmUgTUQsIENocmlzdGluZSBKCiAgICAgICAgU2lnbmVkIEJ5OiBDdXJlIE1ELCBDaHJpc3RpbmUgSgogICAgICAgIFNpZ25lZCBEYXRlL1RpbWU6IDAyLzAzLzE5IDc6NDQgcG0KICAgICAgICBUcmFuc2NyaWJlZCBCeTogQ1NCCiAgICAgICAgVHJhbnNjcmliZWQgRGF0ZS9UaW1lOiAwMi8wMy8xOSA3OjQzIHBtPC9wPgogICAgICAKICAgICAgCiAgPC9ib2R5Pgo8L2h0bWw+Cg=="
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-diagnostic-report-note</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Encounter/usqualitycore-encounter"
+      },
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "usqualitycore-encounter",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-encounter"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+            "value": "IMP"
+          }
+        ],
+        "status": "in-progress",
+        "class": {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+          "code": "IMP",
+          "display": "inpatient encounter"
+        },
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://www.ama-assn.org/go/cpt",
+                "code": "99223",
+                "display": "Initial hospital inpatient or observation care, per day, for the evaluation and management of a patient, which requires a medically appropriate history and/or examination and high level of medical decision making. When using total time on the date of the encounter for code selection, 75 minutes must be met or exceeded."
+              }
+            ]
+          }
+        ],
+        "priority": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ActPriority",
+              "code": "R",
+              "display": "routine"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "participant": [
+          {
+            "type": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code": "PPRF",
+                    "display": "primary performer"
+                  }
+                ]
+              }
+            ],
+            "period": {
+              "start": "2015-02-15T14:30:00+01:00",
+              "end": "2015-02-15T16:30:00+01:00"
+            },
+            "individual": {
+              "reference": "Practitioner/usqualitycore-practitioner"
+            }
+          }
+        ],
+        "period": {
+          "start": "2015-02-15T14:30:00+01:00",
+          "end": "2015-02-15T16:30:00+01:00"
+        },
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "247824007",
+                "display": "Fear of becoming fat"
+              }
+            ]
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/usqualitycore-condition-problems-health-concerns"
+          }
+        ],
+        "hospitalization": {
+          "dischargeDisposition": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/discharge-disposition",
+                "code": "home",
+                "display": "Home"
+              }
+            ]
+          }
+        },
+        "location": [
+          {
+            "location": {
+              "reference": "Location/usqualitycore-location"
+            },
+            "period": {
+              "start": "2015-02-15T14:30:00+01:00",
+              "end": "2015-02-15T16:30:00+01:00"
+            }
+          }
+        ],
+        "serviceProvider": {
+          "reference": "Organization/usqualitycore-organization"
+        },
+        "diagnosis": [
+          {
+            "extension": [
+              {
+                "url": "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-encounter-diagnosisPresentOnAdmission",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://www.cms.gov/Medicare/Medicare-Fee-for-Service-Payment/HospitalAcqCond/Coding",
+                      "code": "Y"
+                    }
+                  ]
+                }
+              }
+            ],
+            "condition": {
+              "reference": "Condition/usqualitycore-condition-problems-health-concerns"
+            },
+            "use": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/diagnosis-role",
+                  "code": "DD",
+                  "display": "Discharge diagnosis"
+                }
+              ]
+            },
+            "rank": 1
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-encounter</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "FamilyMemberHistory/usqualitycore-family-member-history"
+      },
+      "resource": {
+        "resourceType": "FamilyMemberHistory",
+        "id": "usqualitycore-family-member-history",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-familymemberhistory"
+          ]
+        },
+        "status": "completed",
+        "patient": {
+          "reference": "Patient/usqualitycore-patient",
+          "display": "Peter Patient"
+        },
+        "date": "2011-03-18T17:49:10+00:00",
+        "relationship": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+              "code": "FTH",
+              "display": "FATHER"
+            }
+          ]
+        },
+        "condition": [
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/familymemberhistory-severity",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://snomed.info/sct",
+                      "code": "399166001",
+                      "display": "Fatal"
+                    }
+                  ]
+                }
+              }
+            ],
+            "code": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "122003",
+                  "display": "Choroidal hemorrhage"
+                }
+              ],
+              "text": "Choroidal hemorrhage"
+            },
+            "outcome": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "520004",
+                  "display": "Congenital bent nose"
+                }
+              ]
+            },
+            "onsetAge": {
+              "value": 74,
+              "unit": "yr",
+              "system": "http://unitsofmeasure.org",
+              "code": "a"
+            },
+            "note": [
+              {
+                "text": "Was fishing at the time. At least he went doing something he loved."
+              }
+            ]
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-family-member-history</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Goal/usqualitycore-goal"
+      },
+      "resource": {
+        "resourceType": "Goal",
+        "id": "usqualitycore-goal",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-goal"
+          ]
+        },
+        "identifier": [
+          {
+            "value": "123"
+          }
+        ],
+        "lifecycleStatus": "on-hold",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/goal-category",
+                "code": "dietary"
+              }
+            ]
+          }
+        ],
+        "priority": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/goal-priority",
+              "code": "high-priority",
+              "display": "High Priority"
+            }
+          ],
+          "text": "high"
+        },
+        "description": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "50064-5",
+              "display": "Ideal body weight"
+            }
+          ],
+          "text": "Target body weight is 160 to 180 lbs."
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient",
+          "display": "Peter James Chalmers"
+        },
+        "startDate": "2015-04-05",
+        "target": [
+          {
+            "measure": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "3141-9",
+                  "display": "Weight Measured"
+                }
+              ]
+            },
+            "detailRange": {
+              "low": {
+                "value": 160,
+                "unit": "lbs",
+                "system": "http://unitsofmeasure.org",
+                "code": "[lb_av]"
+              },
+              "high": {
+                "value": 180,
+                "unit": "lbs",
+                "system": "http://unitsofmeasure.org",
+                "code": "[lb_av]"
+              }
+            },
+            "dueDate": "2016-04-05"
+          }
+        ],
+        "statusDate": "2016-02-14",
+        "statusReason": "Patient wants to defer weight loss until after honeymoon.",
+        "expressedBy": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "addresses": [
+          {
+            "display": "obesity condition"
+          }
+        ],
+        "outcomeReference": [
+          {
+            "reference": "Observation/usqualitycore-observation-lab",
+            "display": "Body Weight Measured"
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-goal</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Group/usqualitycore-group"
+      },
+      "resource": {
+        "resourceType": "Group",
+        "id": "usqualitycore-group",
+        "active": true,
+        "type": "person",
+        "actual": true,
+        "name": "US Quality Core Test Patient Group",
+        "quantity": 1,
+        "member": [
+          {
+            "entity": {
+              "reference": "Patient/usqualitycore-patient"
+            }
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-group</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Immunization/usqualitycore-immunization"
+      },
+      "resource": {
+        "resourceType": "Immunization",
+        "id": "usqualitycore-immunization",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-immunization"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234"
+          }
+        ],
+        "status": "completed",
+        "statusReason": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ActReason",
+              "code": "IMMUNE",
+              "display": "immunity"
+            }
+          ]
+        },
+        "vaccineCode": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/sid/cvx",
+              "code": "197",
+              "display": "Influenza, high-dose, quadrivalent, PF"
+            },
+            {
+              "system": "http://hl7.org/fhir/sid/ndc",
+              "code": "49281012165",
+              "display": "FLUZONE High-Dose Quadrivalent Northern Hemisphere, 10 SYRINGE, GLASS in 1 PACKAGE (49281-121-65) > .7 mL in 1 SYRINGE, GLASS (49281-121-88) (package)"
+            }
+          ],
+          "text": "Influenza, high-dose, quadrivalent, PF"
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "occurrenceDateTime": "2013-01-01",
+        "recorded": "2013-01-10",
+        "primarySource": true,
+        "location": {
+          "reference": "Location/usqualitycore-location"
+        },
+        "manufacturer": {
+          "reference": "Organization/usqualitycore-organization"
+        },
+        "lotNumber": "AAJN11K",
+        "expirationDate": "2015-02-15",
+        "site": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ActSite",
+              "code": "LA",
+              "display": "left arm"
+            }
+          ]
+        },
+        "route": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-RouteOfAdministration",
+              "code": "IM",
+              "display": "Injection, intramuscular"
+            }
+          ]
+        },
+        "doseQuantity": {
+          "value": 5,
+          "system": "http://unitsofmeasure.org",
+          "code": "mg"
+        },
+        "performer": [
+          {
+            "function": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0443",
+                  "code": "OP"
+                }
+              ]
+            },
+            "actor": {
+              "reference": "Practitioner/usqualitycore-practitioner"
+            }
+          },
+          {
+            "function": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0443",
+                  "code": "AP"
+                }
+              ]
+            },
+            "actor": {
+              "reference": "Practitioner/usqualitycore-practitioner"
+            }
+          }
+        ],
+        "note": [
+          {
+            "text": "Notes on adminstration of vaccine"
+          }
+        ],
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "429060002"
+              }
+            ]
+          }
+        ],
+        "reaction": [
+          {
+            "date": "2013-01-10",
+            "detail": {
+              "reference": "Observation/usqualitycore-observation-lab"
+            },
+            "reported": true
+          }
+        ],
+        "protocolApplied": [
+          {
+            "series": "Vaccination Series 1",
+            "authority": {
+              "reference": "Organization/usqualitycore-organization"
+            },
+            "targetDisease": [
+              {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "1857005"
+                  }
+                ]
+              }
+            ],
+            "doseNumberPositiveInt": 1,
+            "seriesDosesPositiveInt": 2
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-immunization</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Immunization/usqualitycore-immunizationnotdone"
+      },
+      "resource": {
+        "resourceType": "Immunization",
+        "id": "usqualitycore-immunizationnotdone",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-immunizationnotdone"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234"
+          }
+        ],
+        "status": "not-done",
+        "statusReason": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ActReason",
+              "code": "MEDPREC",
+              "display": "medical precaution"
+            }
+          ]
+        },
+        "vaccineCode": {
+          "extension": [
+            {
+              "url": "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-notDoneValueSet",
+              "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1254"
+            }
+          ],
+          "text": "Not Done Value Set: Influenza vaccine"
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "occurrenceDateTime": "2013-01-01",
+        "recorded": "2013-01-10",
+        "primarySource": true,
+        "location": {
+          "reference": "Location/usqualitycore-location"
+        },
+        "manufacturer": {
+          "reference": "Organization/usqualitycore-organization"
+        },
+        "lotNumber": "AAJN11K",
+        "expirationDate": "2015-02-15",
+        "site": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ActSite",
+              "code": "LA",
+              "display": "left arm"
+            }
+          ]
+        },
+        "route": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-RouteOfAdministration",
+              "code": "IM",
+              "display": "Injection, intramuscular"
+            }
+          ]
+        },
+        "doseQuantity": {
+          "value": 5,
+          "system": "http://unitsofmeasure.org",
+          "code": "mg"
+        },
+        "performer": [
+          {
+            "function": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0443",
+                  "code": "OP"
+                }
+              ]
+            },
+            "actor": {
+              "reference": "Practitioner/usqualitycore-practitioner"
+            }
+          },
+          {
+            "function": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0443",
+                  "code": "AP"
+                }
+              ]
+            },
+            "actor": {
+              "reference": "Practitioner/usqualitycore-practitioner"
+            }
+          }
+        ],
+        "note": [
+          {
+            "text": "Notes on adminstration of vaccine"
+          }
+        ],
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "429060002"
+              }
+            ]
+          }
+        ],
+        "reaction": [
+          {
+            "date": "2013-01-10",
+            "detail": {
+              "reference": "Observation/usqualitycore-observation-lab"
+            },
+            "reported": true
+          }
+        ],
+        "protocolApplied": [
+          {
+            "series": "Vaccination Series 1",
+            "authority": {
+              "reference": "Organization/usqualitycore-organization"
+            },
+            "targetDisease": [
+              {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "1857005"
+                  }
+                ]
+              }
+            ],
+            "doseNumberPositiveInt": 1,
+            "seriesDosesPositiveInt": 2
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-immunizationnotdone</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Immunization/usqualitycore-immunizationnotdone-2"
+      },
+      "resource": {
+        "resourceType": "Immunization",
+        "id": "usqualitycore-immunizationnotdone-2",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-immunizationnotdone"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234"
+          }
+        ],
+        "status": "not-done",
+        "statusReason": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ActReason",
+              "code": "MEDPREC",
+              "display": "medical precaution"
+            }
+          ]
+        },
+        "vaccineCode": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/sid/cvx",
+              "code": "197",
+              "display": "Influenza, high-dose, quadrivalent, PF"
+            },
+            {
+              "system": "http://hl7.org/fhir/sid/ndc",
+              "code": "49281012165",
+              "display": "FLUZONE High-Dose Quadrivalent Northern Hemisphere, 10 SYRINGE, GLASS in 1 PACKAGE (49281-121-65) > .7 mL in 1 SYRINGE, GLASS (49281-121-88) (package)"
+            }
+          ],
+          "text": "Influenza, high-dose, quadrivalent, PF"
+        },
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "occurrenceDateTime": "2013-01-01",
+        "recorded": "2013-01-10",
+        "primarySource": true,
+        "location": {
+          "reference": "Location/usqualitycore-location"
+        },
+        "manufacturer": {
+          "reference": "Organization/usqualitycore-organization"
+        },
+        "lotNumber": "AAJN11K",
+        "expirationDate": "2015-02-15",
+        "site": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ActSite",
+              "code": "LA",
+              "display": "left arm"
+            }
+          ]
+        },
+        "route": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-RouteOfAdministration",
+              "code": "IM",
+              "display": "Injection, intramuscular"
+            }
+          ]
+        },
+        "doseQuantity": {
+          "value": 5,
+          "system": "http://unitsofmeasure.org",
+          "code": "mg"
+        },
+        "performer": [
+          {
+            "function": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0443",
+                  "code": "OP"
+                }
+              ]
+            },
+            "actor": {
+              "reference": "Practitioner/usqualitycore-practitioner"
+            }
+          },
+          {
+            "function": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0443",
+                  "code": "AP"
+                }
+              ]
+            },
+            "actor": {
+              "reference": "Practitioner/usqualitycore-practitioner"
+            }
+          }
+        ],
+        "note": [
+          {
+            "text": "Notes on adminstration of vaccine"
+          }
+        ],
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "429060002"
+              }
+            ]
+          }
+        ],
+        "reaction": [
+          {
+            "date": "2013-01-10",
+            "detail": {
+              "reference": "Observation/usqualitycore-observation-lab"
+            },
+            "reported": true
+          }
+        ],
+        "protocolApplied": [
+          {
+            "series": "Vaccination Series 1",
+            "authority": {
+              "reference": "Organization/usqualitycore-organization"
+            },
+            "targetDisease": [
+              {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "1857005"
+                  }
+                ]
+              }
+            ],
+            "doseNumberPositiveInt": 1,
+            "seriesDosesPositiveInt": 2
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-immunizationnotdone-2</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Location/usqualitycore-location"
+      },
+      "resource": {
+        "resourceType": "Location",
+        "id": "usqualitycore-location",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-location"
+          ]
+        },
+        "identifier": [
+          {
+            "use": "temp",
+            "system": "http://exampleoflocation.com",
+            "value": "B1-S.F2"
+          }
+        ],
+        "status": "active",
+        "name": "South Wing, second floor",
+        "alias": [
+          "Mean Joe Greene University Medical Center, South Wing, second floor",
+          "BU MC, SW, F2"
+        ],
+        "description": "Second floor of the Old South Wing, formerly in use by Psychiatry",
+        "mode": "instance",
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                "code": "HOSP",
+                "display": "Hospital"
+              }
+            ]
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "2328",
+            "use": "work"
+          },
+          {
+            "system": "fax",
+            "value": "2329",
+            "use": "work"
+          },
+          {
+            "system": "email",
+            "value": "secondwing@meanjoegreeneuniversitymedicalcenter.com"
+          },
+          {
+            "system": "url",
+            "value": "http://sampleorg.com/southwing",
+            "use": "work"
+          }
+        ],
+        "address": {
+          "use": "work",
+          "line": [
+            "Iron Curtain 75, Building A"
+          ],
+          "city": "Pittsburgh",
+          "state": "PA",
+          "postalCode": "15016",
+          "country": "US"
+        },
+        "physicalType": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code": "wi",
+              "display": "Wing"
+            }
+          ]
+        },
+        "position": {
+          "longitude": -83.6945691,
+          "latitude": 42.25475478,
+          "altitude": 0
+        },
+        "managingOrganization": {
+          "reference": "Organization/usqualitycore-organization"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-location</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Medication/usqualitycore-medication"
+      },
+      "resource": {
+        "resourceType": "Medication",
+        "id": "usqualitycore-medication",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-medication"
+          ]
+        },
+        "contained": [
+          {
+            "resourceType": "Organization",
+            "id": "org6",
+            "meta": {
+              "profile": [
+                "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-organization"
+              ]
+            },
+            "identifier": [
+              {
+                "use": "temp",
+                "system": "http://hl7.org/fhir/sid/us-npi",
+                "value": "8635143786"
+              }
+            ],
+            "active": true,
+            "name": "Genzyme",
+            "telecom": [
+              {
+                "system": "url",
+                "value": "https://www.sanofigenzyme.com/",
+                "use": "work"
+              }
+            ],
+            "address": [
+              {
+                "use": "work",
+                "city": "Cambridge",
+                "state": "MA",
+                "country": "USA"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "1594660",
+              "display": "alemtuzumab 10 MG/ML [Lemtrada]"
+            }
+          ]
+        },
+        "manufacturer": {
+          "reference": "#org6"
+        },
+        "form": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "385219001",
+              "display": "Conventional release solution for injection (dose form)"
+            }
+          ]
+        },
+        "ingredient": [
+          {
+            "itemCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "129472003",
+                  "display": "Alemtuzumab (substance)"
+                }
+              ]
+            },
+            "strength": {
+              "numerator": {
+                "value": 12,
+                "system": "http://unitsofmeasure.org",
+                "code": "mg"
+              },
+              "denominator": {
+                "value": 1.2,
+                "system": "http://unitsofmeasure.org",
+                "code": "mL"
+              }
+            }
+          }
+        ],
+        "batch": {
+          "lotNumber": "9494788",
+          "expirationDate": "2017-05-22"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-medication</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "MedicationAdministration/usqualitycore-medicationadministration"
+      },
+      "resource": {
+        "resourceType": "MedicationAdministration",
+        "id": "usqualitycore-medicationadministration",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-medicationadministration"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-recorded",
+            "valueDateTime": "2017-01-17"
+          }
+        ],
+        "status": "completed",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "1594660",
+              "display": "alemtuzumab 10 MG/ML [Lemtrada]"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient",
+          "display": "Donald Duck"
+        },
+        "supportingInformation": [
+          {
+            "reference": "Condition/usqualitycore-condition-problems-health-concerns"
+          }
+        ],
+        "effectivePeriod": {
+          "start": "2015-01-15T14:30:00+01:00",
+          "end": "2015-01-15T14:30:00+01:00"
+        },
+        "request": {
+          "reference": "MedicationRequest/usqualitycore-medicationrequest"
+        },
+        "dosage": {
+          "route": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "47625008",
+                "display": "Intravenous route (qualifier value)"
+              }
+            ]
+          },
+          "dose": {
+            "value": 3,
+            "unit": "mg",
+            "system": "http://unitsofmeasure.org",
+            "code": "mg"
+          }
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-medicationadministration</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "MedicationAdministration/usqualitycore-medicationadministrationnotdone"
+      },
+      "resource": {
+        "resourceType": "MedicationAdministration",
+        "id": "usqualitycore-medicationadministrationnotdone",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-medicationadministrationnotdone"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-recorded",
+            "valueDateTime": "2017-01-17"
+          }
+        ],
+        "status": "not-done",
+        "statusReason": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "183966005",
+                "display": "Drug treatment not indicated (situation)"
+              }
+            ]
+          }
+        ],
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "1594660",
+              "display": "alemtuzumab 10 MG/ML [Lemtrada]"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient",
+          "display": "Donald Duck"
+        },
+        "supportingInformation": [
+          {
+            "reference": "Condition/usqualitycore-condition-problems-health-concerns"
+          }
+        ],
+        "effectivePeriod": {
+          "start": "2015-01-15T14:30:00+01:00",
+          "end": "2015-01-15T14:30:00+01:00"
+        },
+        "request": {
+          "reference": "MedicationRequest/usqualitycore-medicationrequest"
+        },
+        "dosage": {
+          "route": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "47625008",
+                "display": "Intravenous route (qualifier value)"
+              }
+            ]
+          },
+          "dose": {
+            "value": 3,
+            "unit": "mg",
+            "system": "http://unitsofmeasure.org",
+            "code": "mg"
+          }
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-medicationadministration</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "MedicationDispense/usqualitycore-medicationdispense"
+      },
+      "resource": {
+        "resourceType": "MedicationDispense",
+        "id": "usqualitycore-medicationdispense",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-medicationdispense"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-recorded",
+            "valueDateTime": "2017-01-17"
+          }
+        ],
+        "status": "completed",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "1594660",
+              "display": "alemtuzumab 10 MG/ML [Lemtrada]"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "context": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "Practitioner/usqualitycore-practitioner"
+            }
+          },
+          {
+            "actor": {
+              "reference": "Organization/usqualitycore-organization"
+            }
+          }
+        ],
+        "authorizingPrescription": [
+          {
+            "reference": "MedicationRequest/usqualitycore-medicationrequest"
+          }
+        ],
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+              "code": "DF",
+              "display": "Daily Fill"
+            }
+          ]
+        },
+        "quantity": {
+          "value": 100,
+          "unit": "ml",
+          "system": "http://unitsofmeasure.org",
+          "code": "ml"
+        },
+        "daysSupply": {
+          "value": 30,
+          "unit": "Day",
+          "system": "http://unitsofmeasure.org",
+          "code": "d"
+        },
+        "whenPrepared": "2012-05-30T16:20:00+00:00",
+        "whenHandedOver": "2012-05-31T10:20:00+00:00",
+        "destination": {
+          "reference": "Location/usqualitycore-location"
+        },
+        "receiver": [
+          {
+            "reference": "Patient/usqualitycore-patient"
+          }
+        ],
+        "dosageInstruction": [
+          {
+            "text": "1 tablet 3 times daily",
+            "timing": {
+              "repeat": {
+                "frequency": 3,
+                "period": 1,
+                "periodUnit": "d"
+              }
+            },
+            "route": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "394899003",
+                  "display": "oral administration of treatment"
+                }
+              ]
+            },
+            "doseAndRate": [
+              {
+                "type": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/dose-rate-type",
+                      "code": "ordered",
+                      "display": "Ordered"
+                    }
+                  ]
+                },
+                "doseQuantity": {
+                  "value": 5,
+                  "unit": "ml",
+                  "system": "http://unitsofmeasure.org",
+                  "code": "ml"
+                }
+              }
+            ]
+          }
+        ],
+        "substitution": {
+          "wasSubstituted": false,
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-substanceAdminSubstitution",
+                "code": "N",
+                "display": "none"
+              }
+            ],
+            "text": "No substitution occurred or is permitted."
+          }
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-medicationdispense</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "MedicationDispense/usqualitycore-medicationdispensedeclined"
+      },
+      "resource": {
+        "resourceType": "MedicationDispense",
+        "id": "usqualitycore-medicationdispensedeclined",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-medicationdispensedeclined"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-recorded",
+            "valueDateTime": "2017-01-17"
+          }
+        ],
+        "status": "declined",
+        "statusReasonCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "397745006",
+              "display": "Medical contraindication"
+            }
+          ]
+        },
+        "medicationCodeableConcept": {
+          "extension": [
+            {
+              "url": "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-notDoneValueSet",
+              "valueCanonical": "http://cts.nlm.nih.gov/fhir/1.3.6.1.4.1.6997.4.1.2.268.13.35211.1.13.1.999.321"
+            }
+          ],
+          "text": "Not Done Value Set: Ophthalmic Antihistamines"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "context": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "Practitioner/usqualitycore-practitioner"
+            }
+          },
+          {
+            "actor": {
+              "reference": "Organization/usqualitycore-organization"
+            }
+          }
+        ],
+        "authorizingPrescription": [
+          {
+            "reference": "MedicationRequest/usqualitycore-medicationrequest"
+          }
+        ],
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+              "code": "DF",
+              "display": "Daily Fill"
+            }
+          ]
+        },
+        "quantity": {
+          "value": 100,
+          "unit": "ml",
+          "system": "http://unitsofmeasure.org",
+          "code": "ml"
+        },
+        "daysSupply": {
+          "value": 30,
+          "unit": "Day",
+          "system": "http://unitsofmeasure.org",
+          "code": "d"
+        },
+        "whenPrepared": "2012-05-30T16:20:00+00:00",
+        "whenHandedOver": "2012-05-31T10:20:00+00:00",
+        "destination": {
+          "reference": "Location/usqualitycore-location"
+        },
+        "receiver": [
+          {
+            "reference": "Patient/usqualitycore-patient"
+          }
+        ],
+        "dosageInstruction": [
+          {
+            "text": "1 tablet 3 times daily",
+            "timing": {
+              "repeat": {
+                "frequency": 3,
+                "period": 1,
+                "periodUnit": "d"
+              }
+            },
+            "route": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "394899003",
+                  "display": "oral administration of treatment"
+                }
+              ]
+            },
+            "doseAndRate": [
+              {
+                "type": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/dose-rate-type",
+                      "code": "ordered",
+                      "display": "Ordered"
+                    }
+                  ]
+                },
+                "doseQuantity": {
+                  "value": 5,
+                  "unit": "ml",
+                  "system": "http://unitsofmeasure.org",
+                  "code": "ml"
+                }
+              }
+            ]
+          }
+        ],
+        "substitution": {
+          "wasSubstituted": false,
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-substanceAdminSubstitution",
+                "code": "N",
+                "display": "none"
+              }
+            ],
+            "text": "No substitution occurred or is permitted."
+          }
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-medicationdispense</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "MedicationRequest/usqualitycore-medicationnotrequested"
+      },
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "usqualitycore-medicationnotrequested",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-medicationnotrequested"
+          ]
+        },
+        "status": "active",
+        "intent": "order",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+                "code": "inpatient",
+                "display": "Inpatient"
+              }
+            ]
+          }
+        ],
+        "doNotPerform": true,
+        "medicationCodeableConcept": {
+          "extension": [
+            {
+              "url": "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-notDoneValueSet",
+              "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.39"
+            }
+          ],
+          "text": "Not Done Value Set: Low Dose Unfractionated Heparin for VTE Prophylaxis"
+        },
+        "reportedReference": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "authoredOn": "2015-03-25T19:32:52-05:00",
+        "requester": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "151811000119109",
+                "display": "Health condition feared but not present"
+              }
+            ]
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/usqualitycore-condition-problems-health-concerns"
+          }
+        ],
+        "dosageInstruction": [
+          {
+            "text": "1 tablet 3 times daily",
+            "timing": {
+              "repeat": {
+                "boundsPeriod": {
+                  "start": "2014",
+                  "end": "2015"
+                },
+                "frequency": 3,
+                "frequencyMax": 3,
+                "period": 1,
+                "periodMax": 1,
+                "periodUnit": "d"
+              }
+            },
+            "asNeededBoolean": false,
+            "route": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "394899003",
+                  "display": "oral administration of treatment"
+                }
+              ]
+            },
+            "doseAndRate": [
+              {
+                "doseQuantity": {
+                  "value": 5,
+                  "unit": "ml",
+                  "system": "http://unitsofmeasure.org",
+                  "code": "ml"
+                }
+              }
+            ]
+          }
+        ],
+        "dispenseRequest": {
+          "numberOfRepeatsAllowed": 3,
+          "quantity": {
+            "value": 100,
+            "unit": "ml",
+            "system": "http://unitsofmeasure.org",
+            "code": "ml"
+          }
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-medicationrequest</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "MedicationRequest/usqualitycore-medicationrequest"
+      },
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "usqualitycore-medicationrequest",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-medicationrequest"
+          ]
+        },
+        "status": "active",
+        "intent": "order",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+                "code": "inpatient",
+                "display": "Inpatient"
+              }
+            ]
+          }
+        ],
+        "doNotPerform": false,
+        "reportedReference": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "1594660",
+              "display": "alemtuzumab 10 MG/ML [Lemtrada]"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "authoredOn": "2015-03-25T19:32:52-05:00",
+        "requester": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "151811000119109",
+                "display": "Health condition feared but not present"
+              }
+            ]
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/usqualitycore-condition-problems-health-concerns"
+          }
+        ],
+        "dosageInstruction": [
+          {
+            "text": "1 tablet 3 times daily",
+            "timing": {
+              "repeat": {
+                "boundsPeriod": {
+                  "start": "2014",
+                  "end": "2015"
+                },
+                "frequency": 3,
+                "frequencyMax": 3,
+                "period": 1,
+                "periodMax": 1,
+                "periodUnit": "d"
+              }
+            },
+            "asNeededBoolean": false,
+            "route": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "394899003",
+                  "display": "oral administration of treatment"
+                }
+              ]
+            },
+            "doseAndRate": [
+              {
+                "doseQuantity": {
+                  "value": 5,
+                  "unit": "ml",
+                  "system": "http://unitsofmeasure.org",
+                  "code": "ml"
+                }
+              }
+            ]
+          }
+        ],
+        "dispenseRequest": {
+          "validityPeriod": {
+            "start": "2019-05-24",
+            "end": "2020-02-24"
+          },
+          "numberOfRepeatsAllowed": 3,
+          "quantity": {
+            "value": 100,
+            "unit": "ml",
+            "system": "http://unitsofmeasure.org",
+            "code": "ml"
+          },
+          "expectedSupplyDuration": {
+            "value": 5,
+            "unit": "days",
+            "system": "http://unitsofmeasure.org",
+            "code": "d"
+          }
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-medicationrequest</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-observation-clinical-result"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-observation-clinical-result",
+        "meta": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/instance-name",
+              "valueString": "Heart rate rhythm Example"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/instance-description",
+              "valueMarkdown": "This is a Heart rate rhythm Example for the *Clinical Result Observation Profile*."
+            }
+          ],
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-observation-clinical-result"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "exam",
+                "display": "Exam"
+              }
+            ],
+            "text": "Exam"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "8884-9",
+              "display": "Heart rate rhythm"
+            }
+          ],
+          "text": "Heart rate rhythm"
+        },
+        "valueString": "Regular (R)",
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "display": "Cardiology Consult"
+        },
+        "effectiveDateTime": "2021-11-10T16:48:57.246958-08:00",
+        "performer": [
+          {
+            "reference": "Practitioner/usqualitycore-practitioner",
+            "display": "Practitioner"
+          }
+        ],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "101692-2",
+                  "display": "Maximum heart rate"
+                }
+              ]
+            }
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-observation-clinical-result</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-observation-clinical-result-2"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-observation-clinical-result-2",
+        "meta": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/instance-name",
+              "valueString": "Heart rate rhythm Example"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/instance-description",
+              "valueMarkdown": "This is a Heart rate rhythm Example for the *Clinical Result Observation Profile*."
+            }
+          ],
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-observation-clinical-result"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "exam",
+                "display": "Exam"
+              }
+            ],
+            "text": "Exam"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "2339-0",
+              "display": "Glucose Bld-mCnc"
+            }
+          ],
+          "text": "Glucose Bld-mCnc"
+        },
+        "valueQuantity": {
+          "value": 76,
+          "unit": "mg/dL",
+          "system": "http://unitsofmeasure.org"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "display": "Cardiology Consult"
+        },
+        "effectiveDateTime": "2021-11-10T16:48:57.246958-08:00",
+        "performer": [
+          {
+            "reference": "Practitioner/usqualitycore-practitioner",
+            "display": "Practitioner"
+          }
+        ],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "101692-2",
+                  "display": "Maximum heart rate"
+                }
+              ]
+            }
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-observation-clinical-result-2</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-observation-clinical-result-3"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-observation-clinical-result-3",
+        "meta": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/instance-name",
+              "valueString": "Heart rate rhythm Example"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/instance-description",
+              "valueMarkdown": "This is a Heart rate rhythm Example for the *Clinical Result Observation Profile*."
+            }
+          ],
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-observation-clinical-result"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "exam",
+                "display": "Exam"
+              }
+            ],
+            "text": "Exam"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "8884-9",
+              "display": "Heart rate rhythm"
+            }
+          ],
+          "text": "Heart rate rhythm"
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "260385009",
+              "display": "Negative"
+            }
+          ],
+          "text": "Negative for Chlamydia Trachomatis rRNA"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "display": "Cardiology Consult"
+        },
+        "effectiveDateTime": "2021-11-10T16:48:57.246958-08:00",
+        "performer": [
+          {
+            "reference": "Practitioner/usqualitycore-practitioner",
+            "display": "Practitioner"
+          }
+        ],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "101692-2",
+                  "display": "Maximum heart rate"
+                }
+              ]
+            }
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-observation-clinical-result-3</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-observation-clinical-result-4"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-observation-clinical-result-4",
+        "meta": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/instance-name",
+              "valueString": "Heart rate rhythm Example"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/instance-description",
+              "valueMarkdown": "This is a Heart rate rhythm Example for the *Clinical Result Observation Profile*."
+            }
+          ],
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-observation-clinical-result"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "exam",
+                "display": "Exam"
+              }
+            ],
+            "text": "Exam"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "8884-9",
+              "display": "Heart rate rhythm"
+            }
+          ],
+          "text": "Heart rate rhythm"
+        },
+        "dataAbsentReason": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/data-absent-reason",
+              "code": "unknown",
+              "display": "Unknown"
+            }
+          ],
+          "text": "Unknown"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "display": "Cardiology Consult"
+        },
+        "effectiveDateTime": "2021-11-10T16:48:57.246958-08:00",
+        "performer": [
+          {
+            "reference": "Practitioner/usqualitycore-practitioner",
+            "display": "Practitioner"
+          }
+        ],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "101692-2",
+                  "display": "Maximum heart rate"
+                }
+              ]
+            }
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-observation-clinical-result-4</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-observation-lab"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-observation-lab",
+        "meta": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/instance-name",
+              "valueString": "Blood Glucose Example"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/instance-description",
+              "valueMarkdown": "This is a blood glucose example for the *US Quality Core Observation Lab Profile*."
+            }
+          ],
+          "versionId": "1165",
+          "lastUpdated": "2016-03-09T15:29:58.328+00:00",
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-observation-lab"
+          ]
+        },
+        "status": "final",
+        "issued": "2013-04-03T15:30:10+01:00",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "2339-0",
+              "display": "Glucose Bld-mCnc"
+            }
+          ],
+          "text": "Glucose Bld-mCnc"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient",
+          "display": "Amy Shaw"
+        },
+        "effectiveDateTime": "2005-07-05",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization",
+            "display": "Hendricks Country Hospital"
+          }
+        ],
+        "valueQuantity": {
+          "value": 76,
+          "unit": "mg/dL",
+          "system": "http://unitsofmeasure.org"
+        },
+        "specimen": {
+          "reference": "Specimen/usqualitycore-specimen"
+        },
+        "referenceRange": [
+          {
+            "low": {
+              "value": 40,
+              "unit": "mg/dL",
+              "system": "http://unitsofmeasure.org",
+              "code": "mg/dL"
+            },
+            "high": {
+              "value": 109,
+              "unit": "mg/dL",
+              "system": "http://unitsofmeasure.org",
+              "code": "mg/dL"
+            },
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/referencerange-meaning",
+                  "code": "normal",
+                  "display": "Normal Range"
+                }
+              ],
+              "text": "Normal Range"
+            }
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-observation-lab</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-observation-lab-2"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-observation-lab-2",
+        "meta": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/instance-name",
+              "valueString": "Blood Glucose Example"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/instance-description",
+              "valueMarkdown": "This is a blood glucose example for the *US Quality Core Observation Lab Profile*."
+            }
+          ],
+          "versionId": "1165",
+          "lastUpdated": "2016-03-09T15:29:58.328+00:00",
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-observation-lab"
+          ]
+        },
+        "status": "final",
+        "issued": "2013-04-03T15:30:10+01:00",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "2339-0",
+              "display": "Glucose Bld-mCnc"
+            }
+          ],
+          "text": "Glucose Bld-mCnc"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient",
+          "display": "Amy Shaw"
+        },
+        "effectiveDateTime": "2005-07-05",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization",
+            "display": "Hendricks Country Hospital"
+          }
+        ],
+        "valueString": "Test",
+        "specimen": {
+          "reference": "Specimen/usqualitycore-specimen"
+        },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                "code": "A",
+                "display": "Abnormal"
+              }
+            ]
+          }
+        ],
+        "referenceRange": [
+          {
+            "low": {
+              "value": 40,
+              "unit": "mg/dL",
+              "system": "http://unitsofmeasure.org",
+              "code": "mg/dL"
+            },
+            "high": {
+              "value": 109,
+              "unit": "mg/dL",
+              "system": "http://unitsofmeasure.org",
+              "code": "mg/dL"
+            },
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/referencerange-meaning",
+                  "code": "normal",
+                  "display": "Normal Range"
+                }
+              ],
+              "text": "Normal Range"
+            }
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-observation-lab-2</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-observation-lab-3"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-observation-lab-3",
+        "meta": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/instance-name",
+              "valueString": "Blood Glucose Example"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/instance-description",
+              "valueMarkdown": "This is a blood glucose example for the *US Quality Core Observation Lab Profile*."
+            }
+          ],
+          "versionId": "1165",
+          "lastUpdated": "2016-03-09T15:29:58.328+00:00",
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-observation-lab"
+          ]
+        },
+        "status": "final",
+        "issued": "2013-04-03T15:30:10+01:00",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "2339-0",
+              "display": "Glucose Bld-mCnc"
+            }
+          ],
+          "text": "Glucose Bld-mCnc"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient",
+          "display": "Amy Shaw"
+        },
+        "effectiveDateTime": "2005-07-05",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization",
+            "display": "Hendricks Country Hospital"
+          }
+        ],
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "260385009",
+              "display": "Negative"
+            }
+          ],
+          "text": "Negative for Chlamydia Trachomatis rRNA"
+        },
+        "specimen": {
+          "reference": "Specimen/usqualitycore-specimen"
+        },
+        "referenceRange": [
+          {
+            "low": {
+              "value": 40,
+              "unit": "mg/dL",
+              "system": "http://unitsofmeasure.org",
+              "code": "mg/dL"
+            },
+            "high": {
+              "value": 109,
+              "unit": "mg/dL",
+              "system": "http://unitsofmeasure.org",
+              "code": "mg/dL"
+            },
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/referencerange-meaning",
+                  "code": "normal",
+                  "display": "Normal Range"
+                }
+              ],
+              "text": "Normal Range"
+            }
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-observation-lab-3</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-observation-lab-4"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-observation-lab-4",
+        "meta": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/instance-name",
+              "valueString": "Blood Glucose Example"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/instance-description",
+              "valueMarkdown": "This is a blood glucose example for the *US Quality Core Observation Lab Profile*."
+            }
+          ],
+          "versionId": "1165",
+          "lastUpdated": "2016-03-09T15:29:58.328+00:00",
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-observation-lab"
+          ]
+        },
+        "status": "final",
+        "issued": "2013-04-03T15:30:10+01:00",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "2339-0",
+              "display": "Glucose Bld-mCnc"
+            }
+          ],
+          "text": "Glucose Bld-mCnc"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient",
+          "display": "Amy Shaw"
+        },
+        "effectiveDateTime": "2005-07-05",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization",
+            "display": "Hendricks Country Hospital"
+          }
+        ],
+        "dataAbsentReason": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/data-absent-reason",
+              "code": "unknown",
+              "display": "Unknown"
+            }
+          ],
+          "text": "Unknown"
+        },
+        "specimen": {
+          "reference": "Specimen/usqualitycore-specimen"
+        },
+        "referenceRange": [
+          {
+            "low": {
+              "value": 40,
+              "unit": "mg/dL",
+              "system": "http://unitsofmeasure.org",
+              "code": "mg/dL"
+            },
+            "high": {
+              "value": 109,
+              "unit": "mg/dL",
+              "system": "http://unitsofmeasure.org",
+              "code": "mg/dL"
+            },
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/referencerange-meaning",
+                  "code": "normal",
+                  "display": "Normal Range"
+                }
+              ],
+              "text": "Normal Range"
+            }
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-observation-lab-4</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-observation-screening-assessment"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-observation-screening-assessment",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-observation-screening-assessment"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "survey",
+                "display": "Survey"
+              }
+            ],
+            "text": "Survey"
+          },
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history",
+                "display": "Social History"
+              },
+              {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
+                "code": "functional-status",
+                "display": "Functional Status"
+              }
+            ],
+            "text": "Functional Status"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "28139-4",
+              "display": "Blood pressure alteration [CCC]"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient",
+          "display": "Amy Shaw"
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "101692-2",
+                  "display": "Maximum heart rate"
+                }
+              ]
+            }
+          }
+        ],
+        "effectiveDateTime": "2005-07-05",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization",
+            "display": "Hendricks Country Hospital"
+          }
+        ],
+        "valueQuantity": {
+          "value": 76,
+          "unit": "mg/dL",
+          "system": "http://unitsofmeasure.org"
+        },
+        "hasMember": [
+          {
+            "reference": "QuestionnaireResponse/usqualitycore-questionnaire-response"
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-observation-screening-assessment</div>"
+        },
+        "derivedFrom": [
+          {
+            "reference": "QuestionnaireResponse/usqualitycore-questionnaire-response"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-observation-screening-assessment-2"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-observation-screening-assessment-2",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-observation-screening-assessment"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "survey",
+                "display": "Survey"
+              }
+            ],
+            "text": "Survey"
+          },
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history",
+                "display": "Social History"
+              },
+              {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
+                "code": "functional-status",
+                "display": "Functional Status"
+              }
+            ],
+            "text": "Functional Status"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "28139-4",
+              "display": "Blood pressure alteration [CCC]"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient",
+          "display": "Amy Shaw"
+        },
+        "effectiveDateTime": "2005-07-05",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization",
+            "display": "Hendricks Country Hospital"
+          }
+        ],
+        "valueString": "Test",
+        "hasMember": [
+          {
+            "reference": "QuestionnaireResponse/usqualitycore-questionnaire-response"
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-observation-screening-assessment-2</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-observation-screening-assessment-3"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-observation-screening-assessment-3",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-observation-screening-assessment"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "survey",
+                "display": "Survey"
+              }
+            ],
+            "text": "Survey"
+          },
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history",
+                "display": "Social History"
+              },
+              {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
+                "code": "functional-status",
+                "display": "Functional Status"
+              }
+            ],
+            "text": "Functional Status"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "28139-4",
+              "display": "Blood pressure alteration [CCC]"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient",
+          "display": "Amy Shaw"
+        },
+        "effectiveDateTime": "2005-07-05",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization",
+            "display": "Hendricks Country Hospital"
+          }
+        ],
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "260385009",
+              "display": "Negative"
+            }
+          ],
+          "text": "Negative for Chlamydia Trachomatis rRNA"
+        },
+        "hasMember": [
+          {
+            "reference": "QuestionnaireResponse/usqualitycore-questionnaire-response"
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-observation-screening-assessment-3</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-observation-screening-assessment-4"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-observation-screening-assessment-4",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-observation-screening-assessment"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "survey",
+                "display": "Survey"
+              }
+            ],
+            "text": "Survey"
+          },
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history",
+                "display": "Social History"
+              },
+              {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
+                "code": "functional-status",
+                "display": "Functional Status"
+              }
+            ],
+            "text": "Functional Status"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "28139-4",
+              "display": "Blood pressure alteration [CCC]"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient",
+          "display": "Amy Shaw"
+        },
+        "effectiveDateTime": "2005-07-05",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization",
+            "display": "Hendricks Country Hospital"
+          }
+        ],
+        "dataAbsentReason": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/data-absent-reason",
+              "code": "unknown",
+              "display": "Unknown"
+            }
+          ],
+          "text": "Unknown"
+        },
+        "hasMember": [
+          {
+            "reference": "QuestionnaireResponse/usqualitycore-questionnaire-response"
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-observation-screening-assessment-4</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-observationcancelled"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-observationcancelled",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-observationcancelled"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-notDoneReason",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "410536001",
+                  "display": "Contraindicated (qualifier value)"
+                }
+              ]
+            }
+          }
+        ],
+        "status": "cancelled",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "activity",
+                "display": "Activity"
+              }
+            ],
+            "text": "Activity"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "99354-3",
+              "display": "Mobility device or aid is regularly used"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectivePeriod": {
+          "start": "2013-04-02T10:30:10+01:00",
+          "end": "2013-04-05T10:30:10+01:00"
+        },
+        "issued": "2013-04-03T15:30:10+01:00",
+        "performer": [
+          {
+            "reference": "Practitioner/usqualitycore-practitioner",
+            "display": "Practitioner"
+          }
+        ],
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "105503008",
+              "display": "Dependence on wheelchair (finding)"
+            }
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-simple-observation</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Organization/usqualitycore-organization"
+      },
+      "resource": {
+        "resourceType": "Organization",
+        "id": "usqualitycore-organization",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-organization"
+          ]
+        },
+        "identifier": [
+          {
+            "use": "temp",
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "1000000004"
+          },
+          {
+            "use": "temp",
+            "system": "http://terminology.hl7.org/NamingSystem/CMSCertificationNumber",
+            "value": "8635143786"
+          },
+          {
+            "use": "temp",
+            "system": "urn:oid:2.16.840.1.113883.4.4",
+            "value": "8635143786"
+          }
+        ],
+        "active": true,
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+                "code": "team",
+                "display": "Organizational team"
+              }
+            ]
+          }
+        ],
+        "name": "Health Level Seven International",
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "(+1) 734-677-7777"
+          },
+          {
+            "system": "fax",
+            "value": "(+1) 734-677-6622"
+          },
+          {
+            "system": "email",
+            "value": "hq@HL7.org"
+          }
+        ],
+        "address": [
+          {
+            "line": [
+              "3300 Washtenaw Avenue, Suite 227"
+            ],
+            "city": "Ann Arbor",
+            "state": "MI",
+            "postalCode": "48104",
+            "country": "USA"
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-organization</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Patient/usqualitycore-patient"
+      },
+      "resource": {
+        "resourceType": "Patient",
+        "id": "usqualitycore-patient",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-patient"
+          ]
+        },
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "code": "2106-3",
+                  "display": "White"
+                }
+              },
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "code": "1002-5",
+                  "display": "American Indian or Alaska Native"
+                }
+              },
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "code": "2028-9",
+                  "display": "Asian"
+                }
+              },
+              {
+                "url": "detailed",
+                "valueCoding": {
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "code": "1586-7",
+                  "display": "Shoshone"
+                }
+              },
+              {
+                "url": "detailed",
+                "valueCoding": {
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "code": "2036-2",
+                  "display": "Filipino"
+                }
+              },
+              {
+                "url": "text",
+                "valueString": "Mixed"
+              }
+            ],
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race|6.1.0"
+          },
+          {
+            "extension": [
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "code": "2135-2",
+                  "display": "Hispanic or Latino"
+                }
+              },
+              {
+                "url": "text",
+                "valueString": "Hispanic or Latino"
+              }
+            ],
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity|6.1.0"
+          },
+          {
+            "extension": [
+              {
+                "url": "tribalAffiliation",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-TribalEntityUS",
+                      "code": "187",
+                      "display": "Paiute-Shoshone Tribe of the Fallon Reservation and Colony, Nevada"
+                    }
+                  ],
+                  "text": "Shoshone"
+                }
+              },
+              {
+                "url": "isEnrolled",
+                "valueBoolean": false
+              }
+            ],
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-tribal-affiliation|6.1.0"
+          },
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex",
+            "valueCode": "248152002"
+          },
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-genderIdentity",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "446141000124107",
+                  "display": "Identifies as female gender (finding)"
+                }
+              ]
+            }
+          }
+        ],
+        "identifier": [
+          {
+            "use": "usual",
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "MR"
+                }
+              ]
+            },
+            "system": "urn:oid:1.2.36.146.595.217.0.1",
+            "value": "12345",
+            "period": {
+              "start": "2001-05-06"
+            },
+            "assigner": {
+              "display": "Acme Healthcare"
+            }
+          }
+        ],
+        "active": true,
+        "name": [
+          {
+            "use": "official",
+            "family": "Chalmers",
+            "suffix": [
+              "Jr"
+            ],
+            "given": [
+              "Peter",
+              "James"
+            ]
+          },
+          {
+            "use": "usual",
+            "family": "Chalmers",
+            "given": [
+              "Jim"
+            ]
+          },
+          {
+            "use": "maiden",
+            "family": "Windsor",
+            "given": [
+              "Peter",
+              "James"
+            ],
+            "period": {
+              "end": "2002"
+            }
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "(03) 5555 6473",
+            "use": "work",
+            "rank": 1
+          },
+          {
+            "system": "phone",
+            "value": "(03) 3410 5613",
+            "use": "mobile",
+            "rank": 2
+          },
+          {
+            "system": "phone",
+            "value": "(03) 5555 8834",
+            "use": "old",
+            "period": {
+              "end": "2014"
+            }
+          }
+        ],
+        "gender": "male",
+        "birthDate": "1974-12-25",
+        "_birthDate": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+              "valueDateTime": "1974-12-25T14:35:45-05:00"
+            }
+          ]
+        },
+        "deceasedBoolean": false,
+        "address": [
+          {
+            "use": "home",
+            "type": "both",
+            "text": "534 Erewhon St PeasantVille, Utah 84414",
+            "line": [
+              "534 Erewhon St"
+            ],
+            "city": "PleasantVille",
+            "district": "Rainbow",
+            "state": "UT",
+            "postalCode": "84414",
+            "period": {
+              "start": "1974-12-25"
+            }
+          }
+        ],
+        "communication": [
+          {
+            "language": {
+              "coding": [
+                {
+                  "system": "urn:ietf:bcp:47",
+                  "code": "es",
+                  "display": "Spanish"
+                }
+              ]
+            },
+            "preferred": true
+          }
+        ],
+        "contact": [
+          {
+            "relationship": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0131",
+                    "code": "N"
+                  }
+                ]
+              }
+            ],
+            "name": {
+              "family": "du Marché",
+              "_family": {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                    "valueString": "VV"
+                  }
+                ]
+              },
+              "given": [
+                "Bénédicte"
+              ]
+            },
+            "telecom": [
+              {
+                "system": "phone",
+                "value": "+33 (237) 998327"
+              }
+            ],
+            "address": {
+              "use": "home",
+              "type": "both",
+              "line": [
+                "534 Erewhon St"
+              ],
+              "city": "PleasantVille",
+              "district": "Rainbow",
+              "state": "VT",
+              "postalCode": "3999",
+              "period": {
+                "start": "1974-12-25"
+              }
+            },
+            "gender": "female",
+            "period": {
+              "start": "2012"
+            }
+          }
+        ],
+        "managingOrganization": {
+          "reference": "Organization/usqualitycore-organization"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-patient</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Practitioner/usqualitycore-practitioner"
+      },
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "usqualitycore-practitioner",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-practitioner"
+          ]
+        },
+        "identifier": [
+          {
+            "use": "temp",
+            "system": "urn:oid:2.16.840.1.113883.4.4",
+            "value": "Practitioner-23"
+          },
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "9941339100"
+          }
+        ],
+        "active": true,
+        "name": [
+          {
+            "family": "Careful",
+            "given": [
+              "Adam"
+            ],
+            "prefix": [
+              "Dr"
+            ]
+          }
+        ],
+        "telecom": [
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-direct",
+                "valueBoolean": true
+              }
+            ],
+            "system": "email",
+            "value": "adam.careful@example.com",
+            "use": "work"
+          }
+        ],
+        "address": [
+          {
+            "use": "home",
+            "line": [
+              "534 Erewhon St"
+            ],
+            "city": "PleasantVille",
+            "state": "UT",
+            "country": "USA",
+            "postalCode": "84414"
+          }
+        ],
+        "qualification": [
+          {
+            "identifier": [
+              {
+                "system": "http://mitre.org/UniversityIdentifier",
+                "value": "12345"
+              }
+            ],
+            "code": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0360|2.0.0",
+                  "code": "BS",
+                  "display": "Bachelor of Science"
+                }
+              ],
+              "text": "Bachelor of Science"
+            },
+            "period": {
+              "start": "1995"
+            },
+            "issuer": {
+              "display": "Example University"
+            }
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-practitioner</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "PractitionerRole/usqualitycore-practitioner-role"
+      },
+      "resource": {
+        "resourceType": "PractitionerRole",
+        "id": "usqualitycore-practitioner-role",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-practitionerrole"
+          ]
+        },
+        "identifier": [
+          {
+            "use": "temp",
+            "system": "https://github.com/inferno-framework/practitionerroles",
+            "value": "31"
+          }
+        ],
+        "active": true,
+        "period": {
+          "start": "1995"
+        },
+        "practitioner": {
+          "reference": "Practitioner/usqualitycore-practitioner",
+          "display": "Dr Adam Careful"
+        },
+        "organization": {
+          "reference": "Organization/usqualitycore-organization"
+        },
+        "code": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "106289002",
+                "display": "Dentist (occupation)"
+              }
+            ]
+          }
+        ],
+        "specialty": [
+          {
+            "coding": [
+              {
+                "system": "http://nucc.org/provider-taxonomy",
+                "code": "122300000X",
+                "display": "Dentist"
+              }
+            ]
+          }
+        ],
+        "location": [
+          {
+            "reference": "Location/usqualitycore-location"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "801-123-4567"
+          }
+        ],
+        "endpoint": [
+          {
+            "reference": "Endpoint/usqualitycore-r4-endpoint"
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-practitioner-role</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Procedure/usqualitycore-procedure"
+      },
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "usqualitycore-procedure",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-procedure"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-recorded",
+            "valueDateTime": "2013-04-05T09:35:00-04:00"
+          }
+        ],
+        "basedOn": [
+          {
+            "reference": "ServiceRequest/usqualitycore-servicerequest"
+          }
+        ],
+        "partOf": [
+          {
+            "reference": "Observation/usqualitycore-observation-lab"
+          }
+        ],
+        "status": "completed",
+        "statusReason": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ActReason",
+              "code": "MEDPREC",
+              "display": "medical precaution"
+            }
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "80146002",
+              "display": "Excision of appendix (procedure)"
+            }
+          ],
+          "text": "Excision of appendix (procedure)"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "performedDateTime": "2013-04-05T09:20:00-04:00",
+        "performer": [
+          {
+            "actor": {
+              "reference": "Practitioner/usqualitycore-practitioner",
+              "display": "Dr Cecil Surgeon"
+            }
+          }
+        ],
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "21522001",
+                "display": "Abdominal pain (finding)"
+              }
+            ]
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "DiagnosticReport/usqualitycore-diagnostic-report-note"
+          }
+        ],
+        "bodySite": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "66754008",
+                "display": "Appendix structure"
+              }
+            ]
+          }
+        ],
+        "report": [
+          {
+            "reference": "DiagnosticReport/usqualitycore-diagnostic-report-lab"
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-procedure</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Procedure/usqualitycore-procedurenotdone"
+      },
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "usqualitycore-procedurenotdone",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-procedurenotdone"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-recorded",
+            "valueDateTime": "2013-04-05T09:35:00-04:00"
+          }
+        ],
+        "basedOn": [
+          {
+            "reference": "ServiceRequest/usqualitycore-servicerequest"
+          }
+        ],
+        "partOf": [
+          {
+            "reference": "Observation/usqualitycore-observation-lab"
+          }
+        ],
+        "status": "not-done",
+        "statusReason": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "183932001",
+              "display": "Procedure contraindicated"
+            }
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "80146002",
+              "display": "Excision of appendix (procedure)"
+            }
+          ],
+          "text": "Excision of appendix (procedure)"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "performedDateTime": "2013-04-05T09:20:00-04:00",
+        "performer": [
+          {
+            "actor": {
+              "reference": "Practitioner/usqualitycore-practitioner",
+              "display": "Dr Cecil Surgeon"
+            }
+          }
+        ],
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "21522001",
+                "display": "Abdominal pain (finding)"
+              }
+            ]
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "DiagnosticReport/usqualitycore-diagnostic-report-note"
+          }
+        ],
+        "bodySite": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "66754008",
+                "display": "Appendix structure"
+              }
+            ]
+          }
+        ],
+        "report": [
+          {
+            "reference": "DiagnosticReport/usqualitycore-diagnostic-report-lab"
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-procedure</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "QuestionnaireResponse/usqualitycore-questionnaire-response"
+      },
+      "resource": {
+        "resourceType": "QuestionnaireResponse",
+        "id": "usqualitycore-questionnaire-response",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-questionnaireresponse"
+          ]
+        },
+        "questionnaire": "http://hl7.org/fhir/uv/sdc/Questionnaire/questionnaire-sdc-profile-example-PHQ9",
+        "status": "completed",
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "authored": "2022-07-31T22:14:07.387Z",
+        "author": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "item": [
+          {
+            "linkId": "H1/T1",
+            "text": "Over the last two weeks, how often have you been bothered by any of the following problems?",
+            "item": [
+              {
+                "linkId": "H1/T1/Q1",
+                "text": "Little interest or pleasure in doing things?",
+                "answer": [
+                  {
+                    "valueCoding": {
+                      "system": "http://hl7.org/fhir/uv/sdc/CodeSystem/CSPHQ9",
+                      "code": "Not-at-all",
+                      "display": "Not at all"
+                    }
+                  }
+                ]
+              },
+              {
+                "linkId": "H1/T1/Q2",
+                "text": "Feeling down, depressed, or hopeless?",
+                "answer": [
+                  {
+                    "valueCoding": {
+                      "system": "http://hl7.org/fhir/uv/sdc/CodeSystem/CSPHQ9",
+                      "code": "Not-at-all",
+                      "display": "Not at all"
+                    }
+                  }
+                ]
+              },
+              {
+                "linkId": "H1/T1/Q3",
+                "text": "Trouble falling or staying asleep, or sleeping too much?",
+                "answer": [
+                  {
+                    "valueCoding": {
+                      "system": "http://hl7.org/fhir/uv/sdc/CodeSystem/CSPHQ9",
+                      "code": "Not-at-all",
+                      "display": "Not at all"
+                    }
+                  }
+                ]
+              },
+              {
+                "linkId": "H1/T1/Q4",
+                "text": "Feeling tired or having little energy?",
+                "answer": [
+                  {
+                    "valueCoding": {
+                      "system": "http://hl7.org/fhir/uv/sdc/CodeSystem/CSPHQ9",
+                      "code": "Several-days",
+                      "display": "Several days"
+                    }
+                  }
+                ]
+              },
+              {
+                "linkId": "H1/T1/Q5",
+                "text": "Poor appetite or overeating?",
+                "answer": [
+                  {
+                    "valueCoding": {
+                      "system": "http://hl7.org/fhir/uv/sdc/CodeSystem/CSPHQ9",
+                      "code": "More than half the days",
+                      "display": "More than half the days"
+                    }
+                  }
+                ]
+              },
+              {
+                "linkId": "H1/T1/Q6",
+                "text": "Feeling bad about yourself - or that you are a failure or have let yourself or your family down?",
+                "answer": [
+                  {
+                    "valueCoding": {
+                      "system": "http://hl7.org/fhir/uv/sdc/CodeSystem/CSPHQ9",
+                      "code": "Several-days",
+                      "display": "Several days"
+                    }
+                  }
+                ]
+              },
+              {
+                "linkId": "H1/T1/Q7",
+                "text": "Trouble concentrating on things, such as reading the newspaper or watching television?",
+                "answer": [
+                  {
+                    "valueCoding": {
+                      "system": "http://hl7.org/fhir/uv/sdc/CodeSystem/CSPHQ9",
+                      "code": "Nearly every day",
+                      "display": "Nearly every day"
+                    }
+                  }
+                ]
+              },
+              {
+                "linkId": "H1/T1/Q8",
+                "text": "Moving or speaking so slowly that other people could gave noticed? Or so fidgety or restless that you have been moving a lot more than usual?",
+                "answer": [
+                  {
+                    "valueCoding": {
+                      "system": "http://hl7.org/fhir/uv/sdc/CodeSystem/CSPHQ9",
+                      "code": "More than half the days",
+                      "display": "More than half the days"
+                    }
+                  }
+                ]
+              },
+              {
+                "linkId": "H1/T1/Q9",
+                "text": "Thoughts that you would be better off dead, or thoughts of hurting yourself in some way?",
+                "answer": [
+                  {
+                    "valueCoding": {
+                      "system": "http://hl7.org/fhir/uv/sdc/CodeSystem/CSPHQ9",
+                      "code": "Several-days",
+                      "display": "Several days"
+                    }
+                  }
+                ]
+              },
+              {
+                "linkId": "H1/TS",
+                "text": "Patient health questionnaire 9 item total score",
+                "answer": [
+                  {
+                    "valueQuantity": {
+                      "value": 13,
+                      "unit": "{score}"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-questionnaire-response</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "RelatedPerson/usqualitycore-related-person"
+      },
+      "resource": {
+        "resourceType": "RelatedPerson",
+        "id": "usqualitycore-related-person",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-relatedperson"
+          ]
+        },
+        "active": true,
+        "patient": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "relationship": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0131",
+                "code": "C"
+              }
+            ]
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "family": "Chalmers",
+            "given": [
+              "Peter",
+              "James"
+            ]
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "(03) 5555 6473",
+            "use": "work"
+          }
+        ],
+        "gender": "male",
+        "address": [
+          {
+            "use": "home",
+            "line": [
+              "534 Erewhon St"
+            ],
+            "city": "PleasantVille",
+            "state": "UT",
+            "postalCode": "84414"
+          }
+        ],
+        "photo": [
+          {
+            "contentType": "image/jpeg",
+            "url": "Binary/f012"
+          }
+        ],
+        "period": {
+          "start": "2012-03-11"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-related-person</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "ServiceRequest/usqualitycore-servicenotrequested"
+      },
+      "resource": {
+        "resourceType": "ServiceRequest",
+        "id": "usqualitycore-servicenotrequested",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-servicenotrequested"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-doNotPerformReason",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "416406003",
+                  "display": "Procedure discontinued (situation)"
+                }
+              ]
+            }
+          }
+        ],
+        "status": "completed",
+        "intent": "order",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "387713003",
+                "display": "Surgical Procedure"
+              }
+            ]
+          },
+          {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
+                "code": "functional-status",
+                "display": "Functional Status"
+              }
+            ],
+            "text": "Functional Status"
+          }
+        ],
+        "priority": "urgent",
+        "doNotPerform": true,
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "80146002",
+              "display": "Excision of appendix (procedure)"
+            }
+          ],
+          "text": "Excision of appendix (procedure)"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "occurrencePeriod": {
+          "start": "2013-04-05",
+          "end": "2013-04-05"
+        },
+        "asNeededBoolean": true,
+        "authoredOn": "2013-04-04",
+        "requester": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "21522001",
+                "display": "Abdominal pain (finding)"
+              }
+            ]
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "DiagnosticReport/usqualitycore-diagnostic-report-note"
+          }
+        ],
+        "bodySite": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "66754008",
+                "display": "Appendix structure"
+              }
+            ]
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-servicerequest</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "ServiceRequest/usqualitycore-servicerequest"
+      },
+      "resource": {
+        "resourceType": "ServiceRequest",
+        "id": "usqualitycore-servicerequest",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-servicerequest"
+          ]
+        },
+        "status": "completed",
+        "intent": "order",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "387713003",
+                "display": "Surgical Procedure"
+              }
+            ]
+          },
+          {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
+                "code": "functional-status",
+                "display": "Functional Status"
+              }
+            ],
+            "text": "Functional Status"
+          }
+        ],
+        "priority": "urgent",
+        "doNotPerform": false,
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "80146002",
+              "display": "Excision of appendix (procedure)"
+            }
+          ],
+          "text": "Excision of appendix (procedure)"
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "occurrencePeriod": {
+          "start": "2013-04-05",
+          "end": "2013-04-05"
+        },
+        "asNeededBoolean": true,
+        "authoredOn": "2013-04-04",
+        "requester": {
+          "reference": "Practitioner/usqualitycore-practitioner"
+        },
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "21522001",
+                "display": "Abdominal pain (finding)"
+              }
+            ]
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "DiagnosticReport/usqualitycore-diagnostic-report-note"
+          }
+        ],
+        "bodySite": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "66754008",
+                "display": "Appendix structure"
+              }
+            ]
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-servicerequest</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-simple-observation"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-simple-observation",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-simple-observation"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "activity",
+                "display": "Activity"
+              }
+            ],
+            "text": "Activity"
+          },
+          {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
+                "code": "functional-status",
+                "display": "Functional Status"
+              }
+            ],
+            "text": "Functional Status"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "99354-3",
+              "display": "Mobility device or aid is regularly used"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectivePeriod": {
+          "start": "2013-04-02T10:30:10+01:00",
+          "end": "2013-04-05T10:30:10+01:00"
+        },
+        "issued": "2013-04-03T15:30:10+01:00",
+        "performer": [
+          {
+            "reference": "Practitioner/usqualitycore-practitioner",
+            "display": "Practitioner"
+          }
+        ],
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "105503008",
+              "display": "Dependence on wheelchair (finding)"
+            }
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-simple-observation</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-simple-observation-2"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-simple-observation-2",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-simple-observation"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "activity",
+                "display": "Activity"
+              }
+            ],
+            "text": "Activity"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "99354-3",
+              "display": "Mobility device or aid is regularly used"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectivePeriod": {
+          "start": "2013-04-02T10:30:10+01:00",
+          "end": "2013-04-05T10:30:10+01:00"
+        },
+        "issued": "2013-04-03T15:30:10+01:00",
+        "performer": [
+          {
+            "reference": "PractitionerRole/usqualitycore-practitioner-role",
+            "display": "Practitioner Role"
+          }
+        ],
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                "code": "A",
+                "display": "Abnormal"
+              }
+            ]
+          }
+        ],
+        "valueBoolean": true,
+        "derivedFrom": [
+          {
+            "reference": "Observation/usqualitycore-simple-observation"
+          }
+        ],
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-simple-observation-2</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-simple-observation-3"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-simple-observation-3",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-simple-observation"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "activity",
+                "display": "Activity"
+              }
+            ],
+            "text": "Activity"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "99354-3",
+              "display": "Mobility device or aid is regularly used"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectiveDateTime": "2013-04-03T10:30:10+01:00",
+        "issued": "2013-04-03T15:30:10+01:00",
+        "performer": [
+          {
+            "reference": "Organization/usqualitycore-organization",
+            "display": "Hendricks Country Hospital"
+          }
+        ],
+        "valueQuantity": {
+          "value": 1,
+          "unit": "score",
+          "system": "http://unitsofmeasure.org",
+          "code": "{score}"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-simple-observation-3</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/usqualitycore-simple-observation-4"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "usqualitycore-simple-observation-4",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-simple-observation"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "activity",
+                "display": "Activity"
+              }
+            ],
+            "text": "Activity"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "99354-3",
+              "display": "Mobility device or aid is regularly used"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "encounter": {
+          "reference": "Encounter/usqualitycore-encounter"
+        },
+        "effectiveDateTime": "2013-04-04T10:30:10+01:00",
+        "issued": "2013-04-04T15:30:10+01:00",
+        "performer": [
+          {
+            "reference": "Practitioner/usqualitycore-practitioner",
+            "display": "Practitioner"
+          }
+        ],
+        "valueString": "Uses a mobility device daily",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: usqualitycore-simple-observation-4</div>"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Task/usqualitycore-task"
+      },
+      "resource": {
+        "resourceType": "Task",
+        "id": "usqualitycore-task",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-task"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p class=\"res-header-id\"><b>Generated Narrative: Task example</b></p><a name=\"example\"> </a><a name=\"hcexample\"> </a><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\"/><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-quality-core-task.html\">US Quality Core Task</a></p></div><p><b>identifier</b>: <code>http://www.acme.org/tasks</code>/19009</p><p><b>status</b>: Draft</p><p><b>intent</b>: proposal</p><p><b>priority</b>: Routine</p><p><b>code</b>: <span title=\"Codes:\">Medication Reconciliation</span></p><p><b>for</b>: <a href=\"Patient-example.html\">Jim Chalmers  Male, DoB: 1974-12-25 ( Medical record number (use: usual, period: 2001-05-06 --&gt; (ongoing)))</a></p><p><b>executionPeriod</b>: 2018-06-11 --&gt; 2018-06-11</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "https://github.com/inferno-framework/ids/tasks",
+            "value": "19009"
+          }
+        ],
+        "status": "accepted",
+        "statusReason": {
+          "text": "Missing"
+        },
+        "reasonCode": {
+          "text": "Cancellation"
+        },
+        "intent": "proposal",
+        "priority": "routine",
+        "code": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/CodeSystem/task-code",
+              "code": "approve",
+              "display": "Activate/approve the focal resource"
+            }
+          ]
+        },
+        "for": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "basedOn": [
+          {
+            "reference": "DiagnosticReport/usqualitycore-diagnostic-report-note"
+          }
+        ],
+        "focus": {
+          "reference": "Immunization/usqualitycore-immunization"
+        },
+        "executionPeriod": {
+          "start": "2018-06-11",
+          "end": "2018-06-11"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Task/usqualitycore-taskrejected"
+      },
+      "resource": {
+        "resourceType": "Task",
+        "id": "usqualitycore-taskrejected",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-taskrejected"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p class=\"res-header-id\"><b>Generated Narrative: Task example</b></p><a name=\"example\"> </a><a name=\"hcexample\"> </a><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\"/><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-quality-core-task.html\">US Quality Core Task</a></p></div><p><b>identifier</b>: <code>http://www.acme.org/tasks</code>/19009</p><p><b>status</b>: Draft</p><p><b>intent</b>: proposal</p><p><b>priority</b>: Routine</p><p><b>code</b>: <span title=\"Codes:\">Medication Reconciliation</span></p><p><b>for</b>: <a href=\"Patient-example.html\">Jim Chalmers  Male, DoB: 1974-12-25 ( Medical record number (use: usual, period: 2001-05-06 --&gt; (ongoing)))</a></p><p><b>executionPeriod</b>: 2018-06-11 --&gt; 2018-06-11</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "https://github.com/inferno-framework/ids/tasks",
+            "value": "19009"
+          }
+        ],
+        "status": "rejected",
+        "statusReason": {
+          "text": "Missing"
+        },
+        "reasonCode": {
+          "text": "Cancellation"
+        },
+        "intent": "proposal",
+        "priority": "routine",
+        "code": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/CodeSystem/task-code",
+              "code": "approve",
+              "display": "Activate/approve the focal resource"
+            }
+          ]
+        },
+        "for": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "basedOn": [
+          {
+            "reference": "DiagnosticReport/usqualitycore-diagnostic-report-note"
+          }
+        ],
+        "focus": {
+          "reference": "Immunization/usqualitycore-immunization"
+        },
+        "executionPeriod": {
+          "start": "2018-06-11",
+          "end": "2018-06-11"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Task/usqualitycore-taskrejected-2"
+      },
+      "resource": {
+        "resourceType": "Task",
+        "id": "usqualitycore-taskrejected-2",
+        "meta": {
+          "profile": [
+            "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-taskrejected"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p class=\"res-header-id\"><b>Generated Narrative: Task example</b></p><a name=\"example\"> </a><a name=\"hcexample\"> </a><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\"/><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-quality-core-task.html\">US Quality Core Task</a></p></div><p><b>identifier</b>: <code>http://www.acme.org/tasks</code>/19009</p><p><b>status</b>: Draft</p><p><b>intent</b>: proposal</p><p><b>priority</b>: Routine</p><p><b>code</b>: <span title=\"Codes:\">Medication Reconciliation</span></p><p><b>for</b>: <a href=\"Patient-example.html\">Jim Chalmers  Male, DoB: 1974-12-25 ( Medical record number (use: usual, period: 2001-05-06 --> (ongoing)))</a></p><p><b>executionPeriod</b>: 2018-06-11 --> 2018-06-11</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "https://github.com/inferno-framework/ids/tasks",
+            "value": "19009"
+          }
+        ],
+        "status": "rejected",
+        "statusReason": {
+          "text": "Missing"
+        },
+        "reasonCode": {
+          "text": "Cancellation"
+        },
+        "intent": "proposal",
+        "priority": "routine",
+        "code": {
+          "extension": [
+            {
+              "url": "http://fhir.org/guides/onc/us-quality-core/StructureDefinition/us-quality-core-notDoneValueSet",
+              "valueCanonical": "http://cts.nlm.nih.gov/fhir/2.16.840.1.113883.3.117.1.7.1.214"
+            }
+          ]
+        },
+        "for": {
+          "reference": "Patient/usqualitycore-patient"
+        },
+        "basedOn": [
+          {
+            "reference": "DiagnosticReport/usqualitycore-diagnostic-report-note"
+          }
+        ],
+        "focus": {
+          "reference": "Immunization/usqualitycore-immunization"
+        },
+        "executionPeriod": {
+          "start": "2018-06-11",
+          "end": "2018-06-11"
+        }
+      }
+    }
+  ]
+}

--- a/resources/us_quality_core_bundle_search_parameters.json
+++ b/resources/us_quality_core_bundle_search_parameters.json
@@ -1,0 +1,299 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "request": {
+        "method": "PUT",
+        "url": "SearchParameter/us-quality-core-adverseevent-recorded-date"
+      },
+      "resource": {
+        "resourceType": "SearchParameter",
+        "id": "us-quality-core-adverseevent-recorded-date",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p class=\"res-header-id\"><b>Generated Narrative: SearchParameter us-quality-core-adverseevent-recorded-date</b></p><a name=\"us-quality-core-adverseevent-recorded-date\"> </a><a name=\"hcus-quality-core-adverseevent-recorded-date\"> </a><h2>UsQualityCoreAdverseeventRecordedDate</h2><p>Parameter <code>recorded-date</code>:<code>date</code></p><div><p>US Quality Core AdverseEvent recorded-date Search Parameter</p>\n</div><table class=\"grid\"><tr><td>Resource</td><td><a href=\"http://hl7.org/fhir/R4/adverseevent.html\">AdverseEvent</a></td></tr><tr><td>Expression</td><td><code>AdverseEvent.recordedDate</code></td></tr><tr><td>Processing Mode</td><td>Normal</td></tr><tr><td>Multiples</td><td><ul><li>multipleAnd: The parameter may repeat in order to specify multiple values that must all be true</li><li>multipleOr: The parameter may have multiple values (separated by comma) where at least one must be true</li></ul></td></tr><tr><td>Comparators</td><td>Allowed: eq, ne, gt, ge, lt, le, sa, eb, ap</td></tr></table></div>"
+        },
+        "url": "http://fhir.org/guides/onc/us-quality-core/SearchParameter/us-quality-core-adverseevent-recorded-date",
+        "version": "0.5.0",
+        "name": "UsQualityCoreAdverseeventRecordedDate",
+        "status": "active",
+        "date": "2026-05-15",
+        "publisher": "ONC",
+        "contact": [
+          {
+            "telecom": [
+              {
+                "system": "url",
+                "value": "https://www.healthit.gov/"
+              }
+            ]
+          }
+        ],
+        "description": "US Quality Core AdverseEvent recorded-date Search Parameter",
+        "jurisdiction": [
+          {
+            "coding": [
+              {
+                "system": "urn:iso:std:iso:3166",
+                "code": "US",
+                "display": "United States of America"
+              }
+            ],
+            "text": "USA"
+          }
+        ],
+        "code": "recorded-date",
+        "base": [
+          "AdverseEvent"
+        ],
+        "type": "date",
+        "expression": "AdverseEvent.recordedDate",
+        "xpathUsage": "normal",
+        "multipleOr": true,
+        "multipleAnd": true,
+        "comparator": [
+          "eq",
+          "ne",
+          "gt",
+          "ge",
+          "lt",
+          "le",
+          "sa",
+          "eb",
+          "ap"
+        ],
+        "_comparator": [
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+              }
+            ]
+          },
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+              }
+            ]
+          },
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHALL"
+              }
+            ]
+          },
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHALL"
+              }
+            ]
+          },
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHALL"
+              }
+            ]
+          },
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHALL"
+              }
+            ]
+          },
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+              }
+            ]
+          },
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+              }
+            ]
+          },
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "SearchParameter/us-quality-core-devicerequest-do-not-perform"
+      },
+      "resource": {
+        "resourceType": "SearchParameter",
+        "id": "us-quality-core-devicerequest-do-not-perform",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p class=\"res-header-id\"><b>Generated Narrative: SearchParameter us-quality-core-devicerequest-do-not-perform</b></p><a name=\"us-quality-core-devicerequest-do-not-perform\"> </a><a name=\"hcus-quality-core-devicerequest-do-not-perform\"> </a><h2>UsQualityCoreDevicerequestDoNotPerform</h2><p>Parameter <code>do-not-perform</code>:<code>token</code></p><div><p>US Quality Core DeviceRequest do-not-perform Search Parameter</p>\n</div><table class=\"grid\"><tr><td>Resource</td><td><a href=\"http://hl7.org/fhir/R4/devicerequest.html\">DeviceRequest</a></td></tr><tr><td>Expression</td><td><code>DeviceRequest.modifierExtension.where(url='http://hl7.org/fhir/5.0/StructureDefinition/extension-DeviceRequest.doNotPerform').value</code></td></tr><tr><td>Processing Mode</td><td>Normal</td></tr><tr><td>Multiples</td><td><ul><li>multipleAnd: The parameter may repeat in order to specify multiple values that must all be true</li><li>multipleOr: The parameter may have multiple values (separated by comma) where at least one must be true</li></ul></td></tr></table></div>"
+        },
+        "url": "http://fhir.org/guides/onc/us-quality-core/SearchParameter/us-quality-core-devicerequest-do-not-perform",
+        "version": "0.5.0",
+        "name": "UsQualityCoreDevicerequestDoNotPerform",
+        "status": "active",
+        "date": "2026-05-15",
+        "publisher": "ONC",
+        "contact": [
+          {
+            "telecom": [
+              {
+                "system": "url",
+                "value": "https://www.healthit.gov/"
+              }
+            ]
+          }
+        ],
+        "description": "US Quality Core DeviceRequest do-not-perform Search Parameter",
+        "jurisdiction": [
+          {
+            "coding": [
+              {
+                "system": "urn:iso:std:iso:3166",
+                "code": "US",
+                "display": "United States of America"
+              }
+            ],
+            "text": "USA"
+          }
+        ],
+        "code": "do-not-perform",
+        "base": [
+          "DeviceRequest"
+        ],
+        "type": "token",
+        "expression": "DeviceRequest.modifierExtension.where(url='http://hl7.org/fhir/5.0/StructureDefinition/extension-DeviceRequest.doNotPerform').value",
+        "xpathUsage": "normal",
+        "multipleOr": true,
+        "multipleAnd": true
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "SearchParameter/us-quality-core-medicationrequest-do-not-perform"
+      },
+      "resource": {
+        "resourceType": "SearchParameter",
+        "id": "us-quality-core-medicationrequest-do-not-perform",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p class=\"res-header-id\"><b>Generated Narrative: SearchParameter us-quality-core-medicationrequest-do-not-perform</b></p><a name=\"us-quality-core-medicationrequest-do-not-perform\"> </a><a name=\"hcus-quality-core-medicationrequest-do-not-perform\"> </a><h2>UsQualityCoreMedicationrequestDoNotPerform</h2><p>Parameter <code>do-not-perform</code>:<code>token</code></p><div><p>US Quality Core MedicationRequest do-not-perform Search Parameter</p>\n</div><table class=\"grid\"><tr><td>Resource</td><td><a href=\"http://hl7.org/fhir/R4/medicationrequest.html\">MedicationRequest</a></td></tr><tr><td>Expression</td><td><code>MedicationRequest.doNotPerform</code></td></tr><tr><td>Processing Mode</td><td>Normal</td></tr><tr><td>Multiples</td><td><ul><li>multipleAnd: The parameter may repeat in order to specify multiple values that must all be true</li><li>multipleOr: The parameter may have multiple values (separated by comma) where at least one must be true</li></ul></td></tr></table></div>"
+        },
+        "url": "http://fhir.org/guides/onc/us-quality-core/SearchParameter/us-quality-core-medicationrequest-do-not-perform",
+        "version": "0.5.0",
+        "name": "UsQualityCoreMedicationrequestDoNotPerform",
+        "status": "active",
+        "date": "2026-05-15",
+        "publisher": "ONC",
+        "contact": [
+          {
+            "telecom": [
+              {
+                "system": "url",
+                "value": "https://www.healthit.gov/"
+              }
+            ]
+          }
+        ],
+        "description": "US Quality Core MedicationRequest do-not-perform Search Parameter",
+        "jurisdiction": [
+          {
+            "coding": [
+              {
+                "system": "urn:iso:std:iso:3166",
+                "code": "US",
+                "display": "United States of America"
+              }
+            ],
+            "text": "USA"
+          }
+        ],
+        "code": "do-not-perform",
+        "base": [
+          "MedicationRequest"
+        ],
+        "type": "token",
+        "expression": "MedicationRequest.doNotPerform",
+        "xpathUsage": "normal",
+        "multipleOr": true,
+        "multipleAnd": true
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "SearchParameter/us-quality-core-servicerequest-do-not-perform"
+      },
+      "resource": {
+        "resourceType": "SearchParameter",
+        "id": "us-quality-core-servicerequest-do-not-perform",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p class=\"res-header-id\"><b>Generated Narrative: SearchParameter us-quality-core-servicerequest-do-not-perform</b></p><a name=\"us-quality-core-servicerequest-do-not-perform\"> </a><a name=\"hcus-quality-core-servicerequest-do-not-perform\"> </a><h2>UsQualityCoreServicerequestDoNotPerform</h2><p>Parameter <code>do-not-perform</code>:<code>token</code></p><div><p>US Quality Core ServiceRequest do-not-perform Search Parameter</p>\n</div><table class=\"grid\"><tr><td>Resource</td><td><a href=\"http://hl7.org/fhir/R4/servicerequest.html\">ServiceRequest</a></td></tr><tr><td>Expression</td><td><code>ServiceRequest.doNotPerform</code></td></tr><tr><td>Processing Mode</td><td>Normal</td></tr><tr><td>Multiples</td><td><ul><li>multipleAnd: The parameter may repeat in order to specify multiple values that must all be true</li><li>multipleOr: The parameter may have multiple values (separated by comma) where at least one must be true</li></ul></td></tr></table></div>"
+        },
+        "url": "http://fhir.org/guides/onc/us-quality-core/SearchParameter/us-quality-core-servicerequest-do-not-perform",
+        "version": "0.5.0",
+        "name": "UsQualityCoreServicerequestDoNotPerform",
+        "status": "active",
+        "date": "2026-05-15",
+        "publisher": "ONC",
+        "contact": [
+          {
+            "telecom": [
+              {
+                "system": "url",
+                "value": "https://www.healthit.gov/"
+              }
+            ]
+          }
+        ],
+        "description": "US Quality Core ServiceRequest do-not-perform Search Parameter",
+        "jurisdiction": [
+          {
+            "coding": [
+              {
+                "system": "urn:iso:std:iso:3166",
+                "code": "US",
+                "display": "United States of America"
+              }
+            ],
+            "text": "USA"
+          }
+        ],
+        "code": "do-not-perform",
+        "base": [
+          "ServiceRequest"
+        ],
+        "type": "token",
+        "expression": "ServiceRequest.doNotPerform",
+        "xpathUsage": "normal",
+        "multipleOr": true,
+        "multipleAnd": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

This PR adds resources and search parameters for the 2026 US Quality Core IG in preparation for deployment of the US Quality Core Test Kit to inferno.healthit.gov.  These resources are used for client tests, as the client tests proxy data served by the inferno.healthit.gov reference server instance to simulate a conformant data exchange partner for the client under test.  They also are used to demonstrate the server tests.  This is patterned off US Core usage of this server.

These patient bundle resources are based off examples in the IG, which themselves were originally provided by QI-Core 6.  However, many updates were made to fill out all 'USCDI+ Quality' tagged elements, while also attempting to retain clinical realism.

The search parameters bundle resources introduce search parameters not supported by base FHIR.  These allow HAPI to index these fields and provide searching of these parameters. 

This PR does not update the Bulk Data cache, as the current use case does not involve accessing the data via a bulk data interface.

# Impacts and side effects

Because this is a shared server, the team considered possible impacts to other uses of the server.

There should not be any ID collisions with existing content on the reference server. 

We do not believe that the number of new resources this adds to the server will have any impact to the performance of the server.  There are only a moderate amount of resources, and there are only a handful of search parameters.

The only known side effect during usage of existing test kits should be an extra patient will be available for selection during SMART App Launches in the 'patient picker' dialog (when a test performs a patient launch).  Several other test kits have added patients over time that show up in this view, and I do not believe having one more patient in that dialog will have any impact to users.

# Testing Guidance

The highest risk impact is on the (g)(10) test kit when being demonstrated against the reference server.  We have verified it is not impacted locally but this should be verified on the QA server.

Note that the docker volume will need to be removed from the reference server's postgres db volume in order to trigger a reimport of this content.  Care should be taken to ensure that the correct volume is deleted, as other services may also provide postgres dbs.