### PR TITLE
Fix us_quality_core_bundle_patient.json validation errors

### DIFF
--- a/resources/us_quality_core_bundle_patient.json
+++ b/resources/us_quality_core_bundle_patient.json
@@ -71,7 +71,6 @@
           "coding": [
             {
               "system": "http://snomed.info/sct",
-              "version": "http://snomed.info/sct/731000124108",
               "code": "119364003",
               "display": "Serum sample"
             },
@@ -240,13 +239,12 @@
         "valueCodeableConcept": {
           "coding": [
             {
-              "system": "http://snomed.info/sct",
-              "version": "http://snomed.info/sct/731000124108",
-              "code": "454381000124105",
-              "display": "Not sure of desire to become pregnant (finding)"
+              "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+              "code": "UNK",
+              "display": "Unknown"
             }
           ],
-          "text": "Not sure of desire to become pregnant (finding)"
+          "text": "Unknown"
         },
         "text": {
           "status": "generated",
@@ -5016,7 +5014,7 @@
             "telecom": [
               {
                 "system": "url",
-                "value": "https://example.com/",
+                "value": "https://www.example.com/",
                 "use": "work"
               }
             ],
@@ -7075,7 +7073,7 @@
                 "valueString": "Mixed"
               }
             ],
-            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race|6.1.0"
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
           },
           {
             "extension": [
@@ -7092,7 +7090,7 @@
                 "valueString": "Hispanic or Latino"
               }
             ],
-            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity|6.1.0"
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
           },
           {
             "extension": [
@@ -7114,7 +7112,7 @@
                 "valueBoolean": false
               }
             ],
-            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-tribal-affiliation|6.1.0"
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-tribal-affiliation"
           },
           {
             "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex",


### PR DESCRIPTION
This PR updates the `us_quality_core_bundle_patient.json` to fix errors in the FHIR validator. See related PR for the US Quality Core Test Kit here for more details: https://github.com/inferno-framework/us-quality-core-test-kit/pull/32

- Remove `|6.1.0` suffixes from Patient extension instance URLs in the example bundle to pass validation.
- Remove conflicting SNOMED `Coding.version` values in example bundle.
- Use `v3-NullFlavor#UNK` for the Pregnancy Intent example value, which is explicitly included in the US Core Pregnancy Intent value set.
- Adds missing `www.` to example URL.

**Note that the docker volume will need to be removed from the reference server's postgres db volume in order to trigger a reimport of this content. Care should be taken to ensure that the correct volume is deleted, as other services may also provide postgres dbs.**